### PR TITLE
Feature #1 자립지원정보 조회

### DIFF
--- a/src/main/java/com/dash/leap/domain/information/controller/InformationController.java
+++ b/src/main/java/com/dash/leap/domain/information/controller/InformationController.java
@@ -1,0 +1,30 @@
+package com.dash.leap.domain.information.controller;
+
+import com.dash.leap.domain.information.controller.docs.InformationControllerDocs;
+import com.dash.leap.domain.information.dto.response.InformationListResponse;
+import com.dash.leap.domain.information.entity.enums.InfoType;
+import com.dash.leap.domain.information.service.InformationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/information")
+@RequiredArgsConstructor
+public class InformationController implements InformationControllerDocs {
+
+    private final InformationService informationService;
+
+    @GetMapping
+    public ResponseEntity<InformationListResponse> readAllInformation(
+            @RequestParam(name = "category", required = false) InfoType infoType,
+            @RequestParam(name = "page", defaultValue = "0") int pageNum,
+            @RequestParam(name = "size", defaultValue = "10") int pageSize) {
+
+        InformationListResponse response = informationService.getInformationList(infoType, pageNum, pageSize);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/dash/leap/domain/information/controller/docs/InformationControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/information/controller/docs/InformationControllerDocs.java
@@ -5,6 +5,7 @@ import com.dash.leap.domain.information.entity.enums.InfoType;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -13,7 +14,10 @@ import org.springframework.web.bind.annotation.RequestParam;
 public interface InformationControllerDocs {
 
     @Operation(summary = "자립지원정보 조회", description = "자립지원정보 목록을 조회합니다.")
-    @ApiResponse(description = "자립지원정보 목록 조회 성공", responseCode = "200")
+    @ApiResponses(value = {
+            @ApiResponse(description = "자립지원정보 목록 조회 성공", responseCode = "200"),
+            @ApiResponse(description = "자립지원정보 목록 조회 실패(잘못된 파라미터 값 입력)", responseCode = "400")
+    })
     ResponseEntity<InformationListResponse> readAllInformation(
             @Parameter(description = "자립지원정보 카테고리(미입력 시 전체 조회)")
             @RequestParam(name = "category", required = false) InfoType infoType,

--- a/src/main/java/com/dash/leap/domain/information/controller/docs/InformationControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/information/controller/docs/InformationControllerDocs.java
@@ -1,0 +1,23 @@
+package com.dash.leap.domain.information.controller.docs;
+
+import com.dash.leap.domain.information.dto.response.InformationListResponse;
+import com.dash.leap.domain.information.entity.enums.InfoType;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "Information", description = "Information API")
+public interface InformationControllerDocs {
+
+    @Operation(summary = "자립지원정보 조회", description = "자립지원정보 목록을 조회합니다.")
+    @ApiResponse(description = "자립지원정보 목록 조회 성공", responseCode = "200")
+    ResponseEntity<InformationListResponse> readAllInformation(
+            @Parameter(description = "자립지원정보 카테고리(미입력 시 전체 조회)")
+            @RequestParam(name = "category", required = false) InfoType infoType,
+            @RequestParam(name = "page", defaultValue = "0") int pageNum,
+            @RequestParam(name = "size", defaultValue = "10") int pageSize
+    );
+}

--- a/src/main/java/com/dash/leap/domain/information/dto/response/InformationListResponse.java
+++ b/src/main/java/com/dash/leap/domain/information/dto/response/InformationListResponse.java
@@ -1,0 +1,21 @@
+package com.dash.leap.domain.information.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+@Schema(description = "자립지원정보 목록에 해당하는 응답입니다.")
+public record InformationListResponse(
+
+        @Schema(description = "자립지원정보 리스트")
+        List<InformationResponse> responseList,
+
+        @Schema(description = "현재 페이지 번호", example = "0")
+        int pageNumber,
+
+        @Schema(description = "페이지 사이즈", example = "10")
+        int pageSize,
+
+        @Schema(description = "다음 페이지 존재 여부", example = "true")
+        boolean hasNext) {
+}

--- a/src/main/java/com/dash/leap/domain/information/dto/response/InformationResponse.java
+++ b/src/main/java/com/dash/leap/domain/information/dto/response/InformationResponse.java
@@ -1,0 +1,28 @@
+package com.dash.leap.domain.information.dto.response;
+
+import com.dash.leap.domain.information.entity.Information;
+import com.dash.leap.domain.information.entity.enums.InfoType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "자립지원정보 상세 정보에 해당하는 응답입니다.")
+public record InformationResponse(
+
+        @Schema(description = "정보 ID", example = "1")
+        Long infoId,
+
+        @Schema(description = "정보 카테고리", example = "진로")
+        InfoType infoType,
+
+        @Schema(description = "정보명", example = "국가근로장학금")
+        String infoTitle,
+
+        @Schema(description = "정보 내용", example = "학자금지원 9구간 이하")
+        String infoContent,
+
+        @Schema(description = "정보 URL", example = "https://career.com/career")
+        String infoUrl) {
+
+    public InformationResponse(Information info) {
+        this(info.getId(), info.getInfoType(), info.getTitle(), info.getContent(), info.getUrl());
+    }
+}

--- a/src/main/java/com/dash/leap/domain/information/entity/Information.java
+++ b/src/main/java/com/dash/leap/domain/information/entity/Information.java
@@ -6,12 +6,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import javax.validation.constraints.NotNull;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
 public class Information extends BaseEntity {
 
     @Id

--- a/src/main/java/com/dash/leap/domain/information/entity/enums/InfoType.java
+++ b/src/main/java/com/dash/leap/domain/information/entity/enums/InfoType.java
@@ -1,6 +1,14 @@
 package com.dash.leap.domain.information.entity.enums;
 
+import lombok.Getter;
+
+@Getter
 public enum InfoType {
-    // 경제, 진로, 주거
-    ECONOMY, CAREER, HOUSING
+    ECONOMY("경제"), CAREER("진로"), HOUSING("주거");
+
+    private final String infoType;
+
+    InfoType(String infoType) {
+        this.infoType = infoType;
+    }
 }

--- a/src/main/java/com/dash/leap/domain/information/repository/InformationRepository.java
+++ b/src/main/java/com/dash/leap/domain/information/repository/InformationRepository.java
@@ -1,0 +1,19 @@
+package com.dash.leap.domain.information.repository;
+
+import com.dash.leap.domain.information.entity.Information;
+import com.dash.leap.domain.information.entity.enums.InfoType;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface InformationRepository extends JpaRepository<Information, Long> {
+
+    @Query("select i from Information i " +
+            "where (:type is null or i.infoType = :type) " +
+            "order by i.createdAt desc")
+    Slice<Information> findByInfoType(@Param("type")InfoType infoType, Pageable pageable);
+}

--- a/src/main/java/com/dash/leap/domain/information/service/InformationService.java
+++ b/src/main/java/com/dash/leap/domain/information/service/InformationService.java
@@ -1,0 +1,36 @@
+package com.dash.leap.domain.information.service;
+
+import com.dash.leap.domain.information.dto.response.InformationListResponse;
+import com.dash.leap.domain.information.dto.response.InformationResponse;
+import com.dash.leap.domain.information.entity.Information;
+import com.dash.leap.domain.information.entity.enums.InfoType;
+import com.dash.leap.domain.information.repository.InformationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class InformationService {
+
+    private final InformationRepository informationRepository;
+
+    public InformationListResponse getInformationList(InfoType infoType, int pageNum, int pageSize) {
+        Pageable pageable = PageRequest.of(pageNum, pageSize);
+        Slice<Information> slice = informationRepository.findByInfoType(infoType, pageable);
+
+        List<InformationResponse> responseList = slice.getContent().stream()
+                .map(InformationResponse::new)
+                .toList();
+
+        return new InformationListResponse(responseList, slice.getNumber(), slice.getSize(), slice.hasNext());
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #1 

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
자립지원정책정보 조회 기능 구현

## 💬 공유사항
- 로그인 기능 구현 전: SecurityConfig requestMatchers에 "/information", "/information/**" 추가해야 함
- 로그인 기능 후 인증 관련 로직 추가해야 함

## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함