### PR TITLE
Feature #19 mission select area

### DIFF
--- a/src/main/java/com/dash/leap/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/dash/leap/domain/mission/controller/MissionController.java
@@ -1,0 +1,27 @@
+package com.dash.leap.domain.mission.controller;
+
+import com.dash.leap.domain.mission.controller.docs.MissionControllerDocs;
+import com.dash.leap.domain.mission.dto.response.MissionAreaResponse;
+import com.dash.leap.domain.mission.service.MissionService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequestMapping("/mission")
+@RequiredArgsConstructor
+public class MissionController implements MissionControllerDocs {
+
+    private final MissionService missionService;
+
+    @GetMapping("/goal")
+    public ResponseEntity<MissionAreaResponse> readMissionArea(@AuthenticationPrincipal Long userId) {
+        MissionAreaResponse response = missionService.getMissionDashboard(userId);
+        return ResponseEntity.ok().body(response);
+    }
+}

--- a/src/main/java/com/dash/leap/domain/mission/controller/docs/MissionControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/mission/controller/docs/MissionControllerDocs.java
@@ -1,0 +1,15 @@
+package com.dash.leap.domain.mission.controller.docs;
+
+import com.dash.leap.domain.mission.dto.response.MissionAreaResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "Mission", description = "Mission API")
+public interface MissionControllerDocs {
+
+    @Operation(summary = "자립목표영역 조회", description = "선택한 자립목표영역 조회를 요청합니다.")
+    @ApiResponse(description = "자립목표영역 조회 성공", responseCode = "200")
+    ResponseEntity<MissionAreaResponse> readMissionArea(Long userId);
+}

--- a/src/main/java/com/dash/leap/domain/mission/dto/response/MissionAreaResponse.java
+++ b/src/main/java/com/dash/leap/domain/mission/dto/response/MissionAreaResponse.java
@@ -1,0 +1,20 @@
+package com.dash.leap.domain.mission.dto.response;
+
+import com.dash.leap.domain.mission.entity.enums.MissionType;
+import com.dash.leap.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "자립목표영역 대시보드 응답입니다.")
+public record MissionAreaResponse(
+
+        @Schema(description = "선택한 자립목표영역", example = "LIFE")
+        MissionType selectedMissionType,
+
+        @Schema(description = "미션 진행률", example = "60")
+        int progress
+) {
+
+    public static MissionAreaResponse from(User user, int progress) {
+        return new MissionAreaResponse(user.getMissionType(), progress);
+    }
+}

--- a/src/main/java/com/dash/leap/domain/mission/entity/Mission.java
+++ b/src/main/java/com/dash/leap/domain/mission/entity/Mission.java
@@ -6,12 +6,14 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import javax.validation.constraints.NotNull;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
 public class Mission extends BaseEntity {
 
     @Id

--- a/src/main/java/com/dash/leap/domain/mission/repository/MissionRecordRepository.java
+++ b/src/main/java/com/dash/leap/domain/mission/repository/MissionRecordRepository.java
@@ -1,0 +1,27 @@
+package com.dash.leap.domain.mission.repository;
+
+import com.dash.leap.domain.mission.entity.MissionRecord;
+import com.dash.leap.domain.mission.entity.enums.MissionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface MissionRecordRepository extends JpaRepository<MissionRecord, Long> {
+
+    @Query("select count(mr) from MissionRecord mr " +
+            "inner join Mission m " +
+                "on mr.mission.id = m.id " +
+            "where mr.user.id = :userId " +
+                "and m.missionType = :type")
+    long countAllByUserAndMissionType(@Param("userId") Long userId, @Param("type") MissionType missionType);
+
+    @Query("select count(mr) from MissionRecord mr " +
+            "inner join Mission m " +
+                "on mr.mission.id = m.id " +
+            "where mr.user.id = :userId " +
+                "and m.missionType = :type " +
+            "and mr.isCompleted = com.dash.leap.domain.mission.entity.enums.MissionStatus.COMPLETED")
+    long countCompletedByUserAndMissionType(@Param("userId") Long userId, @Param("type") MissionType missionType);
+}

--- a/src/main/java/com/dash/leap/domain/mission/service/MissionService.java
+++ b/src/main/java/com/dash/leap/domain/mission/service/MissionService.java
@@ -1,0 +1,42 @@
+package com.dash.leap.domain.mission.service;
+
+import com.dash.leap.domain.mission.dto.response.MissionAreaResponse;
+import com.dash.leap.domain.mission.entity.enums.MissionType;
+import com.dash.leap.domain.mission.repository.MissionRecordRepository;
+import com.dash.leap.domain.user.entity.User;
+import com.dash.leap.domain.user.repository.UserRepository;
+import com.dash.leap.global.exception.NotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MissionService {
+
+    public final UserRepository userRepository;
+    public final MissionRecordRepository missionRecordRepository;
+
+    public MissionAreaResponse getMissionDashboard(Long userId) {
+        User user = getUserOrElseThrow(userId);
+
+        MissionType selected = user.getMissionType();
+        long total = missionRecordRepository.countAllByUserAndMissionType(userId, selected);
+        long completed = missionRecordRepository.countCompletedByUserAndMissionType(userId, selected);
+
+        /**
+         * total = 0 -> 진행률 0
+         * 집계 O -> 백분율로 계산
+         */
+        int progress = total == 0 ? 0 : (int) Math.round((double) completed / total * 100);
+        return new MissionAreaResponse(selected, progress);
+    }
+
+    private User getUserOrElseThrow(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(NotFoundException::new);
+    }
+}

--- a/src/main/java/com/dash/leap/domain/user/controller/UserController.java
+++ b/src/main/java/com/dash/leap/domain/user/controller/UserController.java
@@ -3,9 +3,11 @@ package com.dash.leap.domain.user.controller;
 import com.dash.leap.domain.user.controller.docs.UserControllerDocs;
 import com.dash.leap.domain.user.dto.request.ChatbotSettingRequest;
 import com.dash.leap.domain.user.dto.request.LoginRequest;
+import com.dash.leap.domain.user.dto.request.MissionAreaSettingRequest;
 import com.dash.leap.domain.user.dto.request.UserRegisterRequest;
 import com.dash.leap.domain.user.dto.response.ChatbotSettingResponse;
 import com.dash.leap.domain.user.dto.response.LoginResponse;
+import com.dash.leap.domain.user.dto.response.MissionAreaSettingResponse;
 import com.dash.leap.domain.user.dto.response.UserRegisterResponse;
 import com.dash.leap.domain.user.service.UserService;
 import jakarta.validation.Valid;
@@ -48,6 +50,15 @@ public class UserController implements UserControllerDocs {
     ) {
         ChatbotSettingResponse chatbotSettingResponse = userService.leapySetting(userId, request);
         return ResponseEntity.ok(chatbotSettingResponse);
+    }
+
+    @PatchMapping("/mission-area")
+    public ResponseEntity<MissionAreaSettingResponse> missionAreaSetting(
+            @Valid @RequestBody MissionAreaSettingRequest request,
+            @AuthenticationPrincipal Long userId
+    ) {
+        MissionAreaSettingResponse settingResponse = userService.missionSetting(userId, request);
+        return ResponseEntity.ok(settingResponse);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/dash/leap/domain/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/user/controller/docs/UserControllerDocs.java
@@ -2,9 +2,11 @@ package com.dash.leap.domain.user.controller.docs;
 
 import com.dash.leap.domain.user.dto.request.ChatbotSettingRequest;
 import com.dash.leap.domain.user.dto.request.LoginRequest;
+import com.dash.leap.domain.user.dto.request.MissionAreaSettingRequest;
 import com.dash.leap.domain.user.dto.request.UserRegisterRequest;
 import com.dash.leap.domain.user.dto.response.ChatbotSettingResponse;
 import com.dash.leap.domain.user.dto.response.LoginResponse;
+import com.dash.leap.domain.user.dto.response.MissionAreaSettingResponse;
 import com.dash.leap.domain.user.dto.response.UserRegisterResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -32,6 +34,13 @@ public interface UserControllerDocs {
     @ApiResponse(description = "설정 성공", responseCode = "200")
     ResponseEntity<ChatbotSettingResponse> chatbotSetting(
             @Valid ChatbotSettingRequest request,
+            Long userId
+    );
+
+    @Operation(summary = "자립목표영역 선정", description = "자립목표영역설정을 요청합니다.")
+    @ApiResponse(description = "목표설정 성공", responseCode = "200")
+    ResponseEntity<MissionAreaSettingResponse> missionAreaSetting(
+            @Valid MissionAreaSettingRequest request,
             Long userId
     );
 

--- a/src/main/java/com/dash/leap/domain/user/dto/request/MissionAreaSettingRequest.java
+++ b/src/main/java/com/dash/leap/domain/user/dto/request/MissionAreaSettingRequest.java
@@ -1,0 +1,11 @@
+package com.dash.leap.domain.user.dto.request;
+
+import com.dash.leap.domain.mission.entity.enums.MissionType;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "자립목표영역 설정 요청입니다.")
+public record MissionAreaSettingRequest(
+        @Schema(description = "자립목표영역 (LIFE: 일상생활기술, SELF: 자기관리기술, MONEY: 돈관리기술, SOCIETY: 사회진출기술", example = "LIFE")
+        MissionType missionType
+) {
+}

--- a/src/main/java/com/dash/leap/domain/user/dto/request/MissionAreaSettingRequest.java
+++ b/src/main/java/com/dash/leap/domain/user/dto/request/MissionAreaSettingRequest.java
@@ -2,10 +2,12 @@ package com.dash.leap.domain.user.dto.request;
 
 import com.dash.leap.domain.mission.entity.enums.MissionType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "자립목표영역 설정 요청입니다.")
 public record MissionAreaSettingRequest(
-        @Schema(description = "자립목표영역 (LIFE: 일상생활기술, SELF: 자기관리기술, MONEY: 돈관리기술, SOCIETY: 사회진출기술", example = "LIFE")
+        @Schema(description = "자립목표영역 (LIFE: 일상생활기술, SELF: 자기관리기술, MONEY: 돈관리기술, SOCIETY: 사회진출기술)", example = "LIFE")
+        @NotNull
         MissionType missionType
 ) {
 }

--- a/src/main/java/com/dash/leap/domain/user/dto/response/MissionAreaSettingResponse.java
+++ b/src/main/java/com/dash/leap/domain/user/dto/response/MissionAreaSettingResponse.java
@@ -1,0 +1,20 @@
+package com.dash.leap.domain.user.dto.response;
+
+import com.dash.leap.domain.mission.entity.enums.MissionType;
+import com.dash.leap.domain.user.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "자립목표 설정 응답입니다.")
+public record MissionAreaSettingResponse(
+
+        @Schema(description = "회원 고유 ID", example = "1")
+        Long id,
+
+        @Schema(description = "선택한 자립목표영역", example = "LIFE")
+        MissionType missionType
+) {
+
+    public static MissionAreaSettingResponse from(User user) {
+        return new MissionAreaSettingResponse(user.getId(), user.getMissionType());
+    }
+}

--- a/src/main/java/com/dash/leap/domain/user/entity/User.java
+++ b/src/main/java/com/dash/leap/domain/user/entity/User.java
@@ -54,6 +54,7 @@ public class User {
 
     private Integer level;
 
+    @Setter(AccessLevel.PUBLIC)
     @Column(name = "mission_area")
     @Enumerated(EnumType.STRING)
     private MissionType missionType;

--- a/src/main/java/com/dash/leap/domain/user/entity/User.java
+++ b/src/main/java/com/dash/leap/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.dash.leap.domain.user.entity;
 
+import com.dash.leap.domain.mission.entity.enums.MissionType;
 import com.dash.leap.domain.user.entity.enums.ChatbotType;
 import com.dash.leap.domain.user.entity.enums.UserType;
 import jakarta.persistence.*;
@@ -52,6 +53,10 @@ public class User {
     private ChatbotType chatbotType;
 
     private Integer level;
+
+    @Column(name = "mission_area")
+    @Enumerated(EnumType.STRING)
+    private MissionType missionType;
 
     @Column(name = "class")
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/dash/leap/domain/user/service/UserService.java
+++ b/src/main/java/com/dash/leap/domain/user/service/UserService.java
@@ -2,9 +2,11 @@ package com.dash.leap.domain.user.service;
 
 import com.dash.leap.domain.user.dto.request.ChatbotSettingRequest;
 import com.dash.leap.domain.user.dto.request.LoginRequest;
+import com.dash.leap.domain.user.dto.request.MissionAreaSettingRequest;
 import com.dash.leap.domain.user.dto.request.UserRegisterRequest;
 import com.dash.leap.domain.user.dto.response.ChatbotSettingResponse;
 import com.dash.leap.domain.user.dto.response.LoginResponse;
+import com.dash.leap.domain.user.dto.response.MissionAreaSettingResponse;
 import com.dash.leap.domain.user.dto.response.UserRegisterResponse;
 import com.dash.leap.domain.user.entity.User;
 import com.dash.leap.domain.user.entity.enums.ChatbotType;
@@ -78,6 +80,13 @@ public class UserService {
         user.setChatbotType(requestChatbotType);
 
         return ChatbotSettingResponse.from(user);
+    }
+
+    @Transactional
+    public MissionAreaSettingResponse missionSetting(Long userId, MissionAreaSettingRequest request) {
+        User user = getUserOrElseThrow(userId);
+        user.setMissionType(request.missionType());
+        return MissionAreaSettingResponse.from(user);
     }
 
     @Transactional

--- a/src/main/java/com/dash/leap/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/dash/leap/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -46,5 +47,13 @@ public class GlobalExceptionHandler {
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.NOT_FOUND.toString(), e.getMessage());
         log.warn("NotFoundExceptionResponse: {}", exceptionResponse);
         return ResponseEntity.status(HttpStatus.NOT_FOUND).body(exceptionResponse);
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    @ApiResponse(responseCode = "400")
+    public ResponseEntity<ExceptionResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), "요청 형식이 올바르지 않거나 잘못된 값이 포함되어 있습니다.");
+        log.warn("HttpMessageNotReadableExceptionResponse: {}", e.getMessage());
+        return ResponseEntity.badRequest().body(exceptionResponse);
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #19

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
- 자립목표영역 설정 로직 구현
- 자립목표영역 대시보드(진행 중인 영역 및 미션 진행률) 로직 구현

## 💬 공유사항
- User 엔티티에 MissionTyp 추가했습니다.  → DB에 mission_area 필드로 존재합니다.
- global 예외 HttpMessageNotReadableException 처리 로직 추가했습니다.
- [x] 목표 관련 데이터가 아직 존재하지 않아서 추가 테스트 필요합니다.

## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함