### PR TITLE
Refactor #25 커뮤니티 Swagger 문서 명세 개선

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/controller/docs/CommunityControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/CommunityControllerDocs.java
@@ -8,8 +8,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "Community", description = "Community API")
 public interface CommunityControllerDocs {
@@ -17,9 +17,8 @@ public interface CommunityControllerDocs {
     // 커뮤니티 게시글 생성
     @Operation(summary = "게시글 생성", description = "커뮤니티에 게시글을 작성합니다.")
     @ApiResponse(responseCode = "201", description = "게시글 생성 성공")
-    @PostMapping("/{communityId}/post")
     ResponseEntity<PostCreateResponse> createPost(
-            @AuthenticationPrincipal Long userId,
+            Long userId,
             @PathVariable(name = "communityId") Long communityId,
             @RequestBody PostCreateRequest request
     );
@@ -27,9 +26,8 @@ public interface CommunityControllerDocs {
     // 커뮤니티 게시글 수정
     @Operation(summary = "게시글 수정", description = "커뮤니티의 특정 게시글을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "게시글 수정 성공")
-    @PatchMapping("/{communityId}/post/{postId}")
     ResponseEntity<PostUpdateResponse> updatePost(
-            @AuthenticationPrincipal Long userId,
+            Long userId,
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             @RequestBody PostUpdateRequest request
@@ -38,10 +36,9 @@ public interface CommunityControllerDocs {
     // 커뮤니티 게시글 삭제
     @Operation(summary = "게시글 삭제", description = "커뮤니티의 특정 게시글을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "게시글 삭제 성공")
-    @DeleteMapping("/{communityId}/post/{postId}")
     ResponseEntity<Void> deletePost(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
-            @AuthenticationPrincipal Long userId
+            Long userId
     );
 }

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/CommunityControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/CommunityControllerDocs.java
@@ -1,20 +1,47 @@
 package com.dash.leap.domain.community.controller.docs;
 
+import com.dash.leap.domain.community.dto.request.PostCreateRequest;
+import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
+import com.dash.leap.domain.community.dto.response.PostCreateResponse;
+import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "Community", description = "Community API")
 public interface CommunityControllerDocs {
 
+    // 커뮤니티 게시글 생성
+    @Operation(summary = "게시글 생성", description = "커뮤니티에 게시글을 작성합니다.")
+    @ApiResponse(responseCode = "201", description = "게시글 생성 성공")
+    @PostMapping("/{communityId}/post")
+    ResponseEntity<PostCreateResponse> createPost(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable(name = "communityId") Long communityId,
+            @RequestBody PostCreateRequest request
+    );
+
+    // 커뮤니티 게시글 수정
+    @Operation(summary = "게시글 수정", description = "커뮤니티의 특정 게시글을 수정합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 수정 성공")
+    @PatchMapping("/{communityId}/post/{postId}")
+    ResponseEntity<PostUpdateResponse> updatePost(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable(name = "communityId") Long communityId,
+            @PathVariable(name = "postId") Long postId,
+            @RequestBody PostUpdateRequest request
+    );
+
     // 커뮤니티 게시글 삭제
-    @Operation(summary = "커뮤니티 게시글 삭제", description = "커뮤니티 내 특정 게시글을 삭제합니다.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "삭제 성공"),
-            @ApiResponse(responseCode = "403", description = "작성자 본인이 아님"),
-            @ApiResponse(responseCode = "404", description = "게시글이 존재하지 않음")
-    })
-    ResponseEntity<Void> deletePost(Long communityId, Long postId, Long userId);
+    @Operation(summary = "게시글 삭제", description = "커뮤니티의 특정 게시글을 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "게시글 삭제 성공")
+    @DeleteMapping("/{communityId}/post/{postId}")
+    ResponseEntity<Void> deletePost(
+            @PathVariable(name = "communityId") Long communityId,
+            @PathVariable(name = "postId") Long postId,
+            @AuthenticationPrincipal Long userId
+    );
 }


### PR DESCRIPTION
## 📌 이슈 번호
closed #25

## 🚀 작업 내용
CommunityControllerDocs에
- 커뮤니티 게시글 생성/수정 API 명세 추가
- 커뮤니티 게시글 삭제 API 명세 수정
- HTTP 매핑 어노테이션 제거
- @AuthenticationPrincipal 어노테이션 제거

## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함