### PR TITLE
Feature #28 community create comment

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
@@ -19,11 +19,11 @@ public class CommentController implements CommentControllerDocs {
     // 커뮤니티 댓글 생성
     @PostMapping("/{communityId}/post/{postId}/comment")
     public ResponseEntity<CommentCreateResponse> createComment(
-            @AuthenticationPrincipal Long userId,
             @PathVariable Long communityId,
             @PathVariable Long postId,
+            @AuthenticationPrincipal Long userId,
             @RequestBody CommentCreateRequest request
     ) {
-        return ResponseEntity.ok(commentService.create(userId, communityId, postId, request));
+        return ResponseEntity.ok(commentService.create(communityId, postId, userId, request));
     }
 }

--- a/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
@@ -1,0 +1,29 @@
+package com.dash.leap.domain.community.controller;
+
+import com.dash.leap.domain.community.controller.docs.CommentControllerDocs;
+import com.dash.leap.domain.community.dto.request.CommentCreateRequest;
+import com.dash.leap.domain.community.dto.response.CommentCreateResponse;
+import com.dash.leap.domain.community.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/community")
+public class CommentController implements CommentControllerDocs {
+
+    private final CommentService commentService;
+
+    // 커뮤니티 댓글 생성
+    @PostMapping("/{communityId}/post/{postId}/comment")
+    public ResponseEntity<CommentCreateResponse> createComment(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long communityId,
+            @PathVariable Long postId,
+            @RequestBody CommentCreateRequest request
+    ) {
+        return ResponseEntity.ok(commentService.create(userId, communityId, postId, request));
+    }
+}

--- a/src/main/java/com/dash/leap/domain/community/controller/PostController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/PostController.java
@@ -1,6 +1,6 @@
 package com.dash.leap.domain.community.controller;
 
-import com.dash.leap.domain.community.controller.docs.CommunityControllerDocs;
+import com.dash.leap.domain.community.controller.docs.PostControllerDocs;
 import com.dash.leap.domain.community.dto.request.PostCreateRequest;
 import com.dash.leap.domain.community.dto.response.PostCreateResponse;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
@@ -14,7 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/community")
-public class PostController implements CommunityControllerDocs {
+public class PostController implements PostControllerDocs {
 
     private final PostService postService;
 

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/CommentControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/CommentControllerDocs.java
@@ -1,0 +1,24 @@
+package com.dash.leap.domain.community.controller.docs;
+
+import com.dash.leap.domain.community.dto.request.CommentCreateRequest;
+import com.dash.leap.domain.community.dto.response.CommentCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Community-Comment", description = "Community-Comment API")
+public interface CommentControllerDocs {
+
+    // 커뮤니티 댓글 생성
+    @Operation(summary = "댓글 생성", description = "커뮤니티 게시글에 댓글을 작성합니다.")
+    @ApiResponse(responseCode = "201", description = "댓글 생성 성공")
+    ResponseEntity<CommentCreateResponse> createComment(
+            @PathVariable(name = "communityId") Long communityId,
+            @PathVariable(name = "postId") Long postId,
+            Long userId,
+            @RequestBody CommentCreateRequest request
+    );
+}

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
@@ -11,8 +11,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
-@Tag(name = "Community", description = "Community API")
-public interface CommunityControllerDocs {
+@Tag(name = "Community-Post", description = "Community-Post API")
+public interface PostControllerDocs {
 
     // 커뮤니티 게시글 생성
     @Operation(summary = "게시글 생성", description = "커뮤니티에 게시글을 작성합니다.")
@@ -41,4 +41,6 @@ public interface CommunityControllerDocs {
             @PathVariable(name = "postId") Long postId,
             Long userId
     );
+
+
 }

--- a/src/main/java/com/dash/leap/domain/community/dto/request/CommentCreateRequest.java
+++ b/src/main/java/com/dash/leap/domain/community/dto/request/CommentCreateRequest.java
@@ -1,0 +1,10 @@
+package com.dash.leap.domain.community.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "커뮤니티 댓글 생성 요청입니다.")
+public record CommentCreateRequest(
+
+        @Schema(description = "댓글 내용", example = "일주일에 스터디 몇 번 진행하나요?")
+        String content
+) {}

--- a/src/main/java/com/dash/leap/domain/community/dto/response/CommentCreateResponse.java
+++ b/src/main/java/com/dash/leap/domain/community/dto/response/CommentCreateResponse.java
@@ -1,0 +1,16 @@
+package com.dash.leap.domain.community.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "커뮤니티 댓글 생성 응답입니다.")
+public record CommentCreateResponse(
+
+        @Schema(description = "댓글 ID", example = "5")
+        Long commentId,
+
+        @Schema(description = "댓글 내용", example = "일주일에 스터디 몇 번 진행하나요?")
+        String content,
+
+        @Schema(description = "메시지", example = "댓글이 성공적으로 등록되었습니다.")
+        String message
+) {}

--- a/src/main/java/com/dash/leap/domain/community/entity/Comment.java
+++ b/src/main/java/com/dash/leap/domain/community/entity/Comment.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import javax.validation.constraints.NotNull;
 
@@ -14,6 +15,7 @@ import static jakarta.persistence.FetchType.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
 public class Comment extends BaseEntity {
 
     @Id

--- a/src/main/java/com/dash/leap/domain/community/repository/CommentRepository.java
+++ b/src/main/java/com/dash/leap/domain/community/repository/CommentRepository.java
@@ -1,0 +1,9 @@
+package com.dash.leap.domain.community.repository;
+
+import com.dash.leap.domain.community.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/dash/leap/domain/community/service/CommentService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/CommentService.java
@@ -1,0 +1,51 @@
+package com.dash.leap.domain.community.service;
+
+import com.dash.leap.domain.community.dto.request.CommentCreateRequest;
+import com.dash.leap.domain.community.dto.response.CommentCreateResponse;
+import com.dash.leap.domain.community.entity.Post;
+import com.dash.leap.domain.community.entity.Comment;
+import com.dash.leap.domain.community.repository.PostRepository;
+import com.dash.leap.domain.community.repository.CommentRepository;
+import com.dash.leap.domain.user.entity.User;
+import com.dash.leap.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommentService {
+
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+    private final UserRepository userRepository;
+
+    // 댓글 생성
+    @Transactional
+    public CommentCreateResponse create(Long communityId, Long postId, Long userId, CommentCreateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
+
+        if (!post.getCommunity().getId().equals(communityId)) {
+            throw new IllegalArgumentException("해당 커뮤니티에 속한 게시글이 아닙니다.");
+        }
+
+        Comment comment = Comment.builder()
+                .content(request.content())
+                .post(post)
+                .user(user)
+                .build();
+
+        Comment savedComment = commentRepository.save(comment);
+
+        return new CommentCreateResponse(
+                savedComment.getId(),
+                savedComment.getContent(),
+                "댓글이 성공적으로 등록되었습니다."
+        );
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
closed #28

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
커뮤니티 댓글 생성 기능 구현
Swagger 문서 post/comment 기능 별로 분리

## 💬 공유사항
Swagger에서 해당 기능 테스트를 하면 로그인이 안되어 있다는 오류 발생 -> CommentController 메소드의 인자 순서 변경으로 해결
그러나, Swagger에서 일부러 파라미터를 잘못 입력하면 예외처리한 결과가 아닌 로그인이 안되어 있다는 이슈가 또 발생 -> 원인 못 찾음


예시를 들어, 설명 드리겠습니다.

현재 post 테이블에는 community_id = 1, post_id = 1인 게시글만 존재합니다.
	•	이 상태에서 **community_id = 1, post_id = 1**로 파라미터를 넘기면 댓글 생성이 정상적으로 잘 동작합니다.

⸻

❗️하지만 문제가 되는 경우:
	•	community_id = 1, post_id = 5
	•	community_id = 3, post_id = 1

위처럼 존재하지 않는 게시글 정보를 넘겼을 경우,
예외처리에 관한 응답이 와야 하는데



‼️ 실제로는 “로그인이 되어 있지 않다”는 메시지가 뜹니다.
(아래 스크린샷 참고)
<img width="1110" alt="스크린샷 2025-04-19 오후 11 36 12" src="https://github.com/user-attachments/assets/04055eef-2c7a-461a-acef-856146487198" />


반면, 게시글 생성/수정/삭제 기능에서는
잘못된 파라미터를 전달하더라도 "로그인 이슈"가 발생하진 않습니다. (CORS 허용 설정도 필요해보입니다.)
(아래 스크린샷 참고)
<img width="1110" alt="스크린샷 2025-04-19 오후 11 38 19" src="https://github.com/user-attachments/assets/2465fd8b-7280-4892-ae98-c9a0a751f84a" />

지금까지 다른 기능을 구현할 때도
@AuthenticationPrincipal Long userId를 사용하는 부분에서
userId가 null로 주입되어 로그인 오류가 반복적으로 발생하는 이슈가 있었습니다.

서칭 결과, Spring Security에서는 @AuthenticationPrincipal 사용 시
UserDetails를 구현한 객체로 주입받는 것이 더 안정적이라는 의견이 많았습니다.
(아래 gpt 스크린샷 참고)
<img width="610" alt="스크린샷 2025-04-19 오후 11 39 52" src="https://github.com/user-attachments/assets/bb9cc162-f49c-4c25-b121-7967d86b1307" />

따라서,
LoginUser implements UserDetails 구조로 전환하고
@AuthenticationPrincipal LoginUser loginUser 방식으로 주입받는 것이 좋을 것 같습니다.



## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함