### PR TITLE
Refactor #33 community auth by userdetails

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
@@ -4,6 +4,7 @@ import com.dash.leap.domain.community.controller.docs.CommentControllerDocs;
 import com.dash.leap.domain.community.dto.request.CommentCreateRequest;
 import com.dash.leap.domain.community.dto.response.CommentCreateResponse;
 import com.dash.leap.domain.community.service.CommentService;
+import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -21,9 +22,9 @@ public class CommentController implements CommentControllerDocs {
     public ResponseEntity<CommentCreateResponse> createComment(
             @PathVariable Long communityId,
             @PathVariable Long postId,
-            @AuthenticationPrincipal Long userId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody CommentCreateRequest request
     ) {
-        return ResponseEntity.ok(commentService.create(communityId, postId, userId, request));
+        return ResponseEntity.ok(commentService.create(communityId, postId, userDetails, request));
     }
 }

--- a/src/main/java/com/dash/leap/domain/community/controller/PostController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/PostController.java
@@ -6,6 +6,7 @@ import com.dash.leap.domain.community.dto.response.PostCreateResponse;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
 import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
 import com.dash.leap.domain.community.service.PostService;
+import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,26 +19,26 @@ public class PostController implements PostControllerDocs {
 
     private final PostService postService;
 
-    // 커뮤니티 게시글  생성
+    // 커뮤니티 게시글 생성
     @PostMapping("/{communityId}/post")
     public ResponseEntity<PostCreateResponse> createPost(
-            @AuthenticationPrincipal Long userId,
-            @PathVariable (name = "communityId") Long communityId,
+            @PathVariable(name = "communityId") Long communityId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody PostCreateRequest request
     ) {
-        return ResponseEntity.ok(postService.create(communityId, request, userId));
+        return ResponseEntity.ok(postService.create(communityId, userDetails, request));
     }
 
     // 커뮤니티 게시글 수정
     @PatchMapping("/{communityId}/post/{postId}")
     public ResponseEntity<PostUpdateResponse> updatePost(
-            @AuthenticationPrincipal Long userId,
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody PostUpdateRequest request
     ) {
         return ResponseEntity.ok(
-                postService.update(postId, request, userId, communityId)
+                postService.update(communityId, postId, userDetails, request )
         );
     }
 
@@ -46,9 +47,9 @@ public class PostController implements PostControllerDocs {
     public ResponseEntity<Void> deletePost(
             @PathVariable Long communityId,
             @PathVariable Long postId,
-            @AuthenticationPrincipal Long userId
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        postService.delete(postId, userId, communityId);
+        postService.delete(communityId, postId, userDetails);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/CommentControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/CommentControllerDocs.java
@@ -2,6 +2,7 @@ package com.dash.leap.domain.community.controller.docs;
 
 import com.dash.leap.domain.community.dto.request.CommentCreateRequest;
 import com.dash.leap.domain.community.dto.response.CommentCreateResponse;
+import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,7 +19,7 @@ public interface CommentControllerDocs {
     ResponseEntity<CommentCreateResponse> createComment(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
-            Long userId,
+            CustomUserDetails userDetails,
             @RequestBody CommentCreateRequest request
     );
 }

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
@@ -4,6 +4,7 @@ import com.dash.leap.domain.community.dto.request.PostCreateRequest;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
 import com.dash.leap.domain.community.dto.response.PostCreateResponse;
 import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
+import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,8 +19,8 @@ public interface PostControllerDocs {
     @Operation(summary = "게시글 생성", description = "커뮤니티에 게시글을 작성합니다.")
     @ApiResponse(responseCode = "201", description = "게시글 생성 성공")
     ResponseEntity<PostCreateResponse> createPost(
-            Long userId,
             @PathVariable(name = "communityId") Long communityId,
+            CustomUserDetails userDetails,
             @RequestBody PostCreateRequest request
     );
 
@@ -27,9 +28,9 @@ public interface PostControllerDocs {
     @Operation(summary = "게시글 수정", description = "커뮤니티의 특정 게시글을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "게시글 수정 성공")
     ResponseEntity<PostUpdateResponse> updatePost(
-            Long userId,
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
+            CustomUserDetails userDetails,
             @RequestBody PostUpdateRequest request
     );
 
@@ -39,8 +40,6 @@ public interface PostControllerDocs {
     ResponseEntity<Void> deletePost(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
-            Long userId
+            CustomUserDetails userDetails
     );
-
-
 }

--- a/src/main/java/com/dash/leap/domain/community/service/CommentService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/CommentService.java
@@ -8,6 +8,7 @@ import com.dash.leap.domain.community.repository.PostRepository;
 import com.dash.leap.domain.community.repository.CommentRepository;
 import com.dash.leap.domain.user.entity.User;
 import com.dash.leap.domain.user.repository.UserRepository;
+import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,11 +22,10 @@ public class CommentService {
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
 
-    // 댓글 생성
+    // 커뮤니티 댓글 생성
     @Transactional
-    public CommentCreateResponse create(Long communityId, Long postId, Long userId, CommentCreateRequest request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    public CommentCreateResponse create(Long communityId, Long postId, CustomUserDetails userDetails, CommentCreateRequest request) {
+        User user = userDetails.user();
 
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));

--- a/src/main/java/com/dash/leap/domain/community/service/CommentService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/CommentService.java
@@ -7,7 +7,6 @@ import com.dash.leap.domain.community.entity.Comment;
 import com.dash.leap.domain.community.repository.PostRepository;
 import com.dash.leap.domain.community.repository.CommentRepository;
 import com.dash.leap.domain.user.entity.User;
-import com.dash.leap.domain.user.repository.UserRepository;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,7 +19,6 @@ public class CommentService {
 
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
-    private final UserRepository userRepository;
 
     // 커뮤니티 댓글 생성
     @Transactional

--- a/src/main/java/com/dash/leap/domain/community/service/PostService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/PostService.java
@@ -10,6 +10,7 @@ import com.dash.leap.domain.community.repository.CommunityRepository;
 import com.dash.leap.domain.community.repository.PostRepository;
 import com.dash.leap.domain.user.entity.User;
 import com.dash.leap.domain.user.repository.UserRepository;
+import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,11 +24,10 @@ public class PostService {
     private final UserRepository userRepository;
     private final CommunityRepository communityRepository;
 
-    // 게시글 생성
+    // 커뮤니티 게시글 생성
     @Transactional
-    public PostCreateResponse create(Long communityId, PostCreateRequest request, Long userId) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자입니다."));
+    public PostCreateResponse create(Long communityId, CustomUserDetails userDetails, PostCreateRequest request) {
+        User user = userDetails.user();
 
         Community community = communityRepository.findById(communityId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 커뮤니티입니다."));
@@ -49,9 +49,11 @@ public class PostService {
         );
     }
 
-    // 게시글 수정
+    // 커뮤니티 게시글 수정
     @Transactional
-    public PostUpdateResponse update(Long postId, PostUpdateRequest request, Long userId, Long communityId) {
+    public PostUpdateResponse update(Long communityId, Long postId, CustomUserDetails userDetails, PostUpdateRequest request) {
+        User user = userDetails.user();
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
@@ -59,7 +61,7 @@ public class PostService {
             throw new IllegalStateException("요청한 커뮤니티에 해당 게시글이 존재하지 않습니다.");
         }
 
-        if (!post.getUser().getId().equals(userId)) {
+        if (!post.getUser().getId().equals(user.getId())) {
             throw new IllegalStateException("게시글 작성자만 수정할 수 있습니다.");
         }
 
@@ -73,9 +75,11 @@ public class PostService {
         );
     }
 
-    // 게시글 삭제
+    // 커뮤니티 게시글 삭제
     @Transactional
-    public void delete(Long postId, Long userId, Long communityId) {
+    public void delete(Long communityId, Long postId, CustomUserDetails userDetails) {
+        User user = userDetails.user();
+
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 게시글입니다."));
 
@@ -83,7 +87,7 @@ public class PostService {
             throw new IllegalStateException("해당 커뮤니티에 속한 게시글이 아닙니다.");
         }
 
-        if (!post.getUser().getId().equals(userId)) {
+        if (!post.getUser().getId().equals(user.getId())) {
             throw new IllegalStateException("게시글 작성자만 삭제할 수 있습니다.");
         }
 

--- a/src/main/java/com/dash/leap/domain/community/service/PostService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/PostService.java
@@ -9,7 +9,6 @@ import com.dash.leap.domain.community.entity.Post;
 import com.dash.leap.domain.community.repository.CommunityRepository;
 import com.dash.leap.domain.community.repository.PostRepository;
 import com.dash.leap.domain.user.entity.User;
-import com.dash.leap.domain.user.repository.UserRepository;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class PostService {
 
     private final PostRepository postRepository;
-    private final UserRepository userRepository;
     private final CommunityRepository communityRepository;
 
     // 커뮤니티 게시글 생성


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #33

## 🚀 작업 내용

1. @AuthenticationPrincipal 파라미터를 기존 Long userId에서 CustomUserDetails userDetails로 변경
2. 기존의 userId → user 조회 로직 제거
CustomUserDetails를 통해 이미 인증된 User 엔티티를 직접 전달받으므로 불필요한 DB 조회 제거됨
3. 관련 서비스 로직 리팩토링
커뮤니티 관련 Controllers, Docs, Service 변경
4. 불필요해진 필드 제거
UserRepository userRepository 같이 더 이상 쓰이지 않는 필드 삭제



## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함