### PR TITLE
Fix #36 cascade 설정으로 댓글 존재 시 게시글 삭제 오류 해결

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/entity/Post.java
+++ b/src/main/java/com/dash/leap/domain/community/entity/Post.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.List;
 
 import static jakarta.persistence.FetchType.*;
 
@@ -36,6 +38,9 @@ public class Post extends BaseEntity {
     @NotNull
     @Column(columnDefinition = "TEXT")
     private String content;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
 
     public void update(String title, String content) {
         this.title = title;


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #36

## 🚀 작업 내용
Post ↔ Comment: 양방향 연관관계 설정을 통해
1) 댓글이 존재하는 게시글도 삭제 가능
2) 게시글을 삭제하면 해당 댓글들이 함께 삭제


## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함