### PR TITLE
Feat #39 커뮤니티 댓글 삭제

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
@@ -27,4 +27,16 @@ public class CommentController implements CommentControllerDocs {
     ) {
         return ResponseEntity.ok(commentService.create(communityId, postId, userDetails, request));
     }
+
+    // 커뮤니티 댓글 삭제
+    @DeleteMapping("/{communityId}/post/{postId}/{commentId}")
+    public ResponseEntity<Void> deleteComment(
+            @PathVariable Long communityId,
+            @PathVariable Long postId,
+            @PathVariable Long commentId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        commentService.delete(communityId, postId, commentId, userDetails);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/CommentControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/CommentControllerDocs.java
@@ -22,4 +22,14 @@ public interface CommentControllerDocs {
             CustomUserDetails userDetails,
             @RequestBody CommentCreateRequest request
     );
+
+    // 커뮤니티 댓글 삭제
+    @Operation(summary = "댓글 삭제", description = "커뮤니티 게시글의 댓글을 삭제합니다.")
+    @ApiResponse(responseCode = "204", description = "댓글 삭제 성공")
+    ResponseEntity<Void> deleteComment(
+            @PathVariable(name = "communityId") Long communityId,
+            @PathVariable(name = "postId") Long postId,
+            @PathVariable(name = "commentId") Long commentId,
+            CustomUserDetails userDetails
+    );
 }

--- a/src/main/java/com/dash/leap/domain/community/service/CommentService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/CommentService.java
@@ -46,4 +46,28 @@ public class CommentService {
                 "댓글이 성공적으로 등록되었습니다."
         );
     }
+
+    // 커뮤니티 댓글 삭제
+    @Transactional
+    public void delete(Long communityId, Long postId, Long commentId, CustomUserDetails userDetails) {
+        User user = userDetails.user();
+
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 댓글입니다."));
+
+        Post post = comment.getPost();
+        if (!post.getId().equals(postId)) {
+            throw new IllegalArgumentException("해당 댓글은 요청한 게시글에 속하지 않습니다.");
+        }
+
+        if (!post.getCommunity().getId().equals(communityId)) {
+            throw new IllegalArgumentException("해당 게시글은 요청한 커뮤니티에 속하지 않습니다.");
+        }
+
+        if (!comment.getUser().getId().equals(user.getId())) {
+            throw new IllegalStateException("댓글 작성자만 삭제할 수 있습니다.");
+        }
+
+        commentRepository.delete(comment);
+    }
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #39

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
커뮤니티 댓글 삭제 기능 구현
기존 CommentControllers, CommentControllersDocs, CommentService 에 해당 로직 추가 

## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함