### PR TITLE
Feat #41 커뮤니티 게시글 전체 목록 조회

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/controller/PostController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/PostController.java
@@ -9,11 +9,10 @@ import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
 import com.dash.leap.domain.community.service.PostService;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -22,12 +21,14 @@ public class PostController implements PostControllerDocs {
 
     private final PostService postService;
 
-    // 커뮤니티 게시글 전체 조회
+    // 커뮤니티 게시글 전체 목록 조회
     @GetMapping("/{communityId}/post")
-    public ResponseEntity<List<PostListAllResponse>> getPostAll(
-            @PathVariable Long communityId
+    public ResponseEntity<Page<PostListAllResponse>> getPostAll(
+            @PathVariable Long communityId,
+            @RequestParam(name = "page", defaultValue = "1") int pageNum,
+            @RequestParam(name = "size", defaultValue = "10") int pageSize
     ) {
-        return ResponseEntity.ok(postService.getPostAll(communityId));
+        return ResponseEntity.ok(postService.getPostAll(communityId, pageNum -1 , pageSize));
     }
 
     // 커뮤니티 게시글 생성

--- a/src/main/java/com/dash/leap/domain/community/controller/PostController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.dash.leap.domain.community.controller;
 
 import com.dash.leap.domain.community.controller.docs.PostControllerDocs;
+import com.dash.leap.domain.community.dto.response.PostListAllResponse;
 import com.dash.leap.domain.community.dto.request.PostCreateRequest;
 import com.dash.leap.domain.community.dto.response.PostCreateResponse;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
@@ -12,12 +13,22 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/community")
 public class PostController implements PostControllerDocs {
 
     private final PostService postService;
+
+    // 커뮤니티 게시글 전체 조회
+    @GetMapping("/{communityId}/post")
+    public ResponseEntity<List<PostListAllResponse>> getPostAll(
+            @PathVariable Long communityId
+    ) {
+        return ResponseEntity.ok(postService.getPostAll(communityId));
+    }
 
     // 커뮤니티 게시글 생성
     @PostMapping("/{communityId}/post")

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
@@ -9,20 +9,22 @@ import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-
-import java.util.List;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Community-Post", description = "Community-Post API")
 public interface PostControllerDocs {
 
-    // 커뮤니티 게시글 전체 조회
-    @Operation(summary = "게시글 전체 조회", description = "커뮤니티에 등록된 게시글 목록을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공")
-    ResponseEntity<List<PostListAllResponse>> getPostAll(
-            @PathVariable(name = "communityId") Long communityId
+    // 커뮤니티 게시글 전체 목록 조회
+    @Operation(summary = "게시글 전체 목록 조회", description = "커뮤니티에 등록된 게시글 전체 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 전체 목록 조회 성공")
+    ResponseEntity<Page<PostListAllResponse>> getPostAll(
+            @PathVariable(name = "communityId") Long communityId,
+            @RequestParam(name = "page", defaultValue = "1") int pageNum,
+            @RequestParam(name = "size", defaultValue = "10") int pageSize
     );
 
     // 커뮤니티 게시글 생성

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
@@ -3,6 +3,7 @@ package com.dash.leap.domain.community.controller.docs;
 import com.dash.leap.domain.community.dto.request.PostCreateRequest;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
 import com.dash.leap.domain.community.dto.response.PostCreateResponse;
+import com.dash.leap.domain.community.dto.response.PostListAllResponse;
 import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -12,8 +13,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 
+import java.util.List;
+
 @Tag(name = "Community-Post", description = "Community-Post API")
 public interface PostControllerDocs {
+
+    // 커뮤니티 게시글 전체 조회
+    @Operation(summary = "게시글 전체 조회", description = "커뮤니티에 등록된 게시글 목록을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 전체 조회 성공")
+    ResponseEntity<List<PostListAllResponse>> getPostAll(
+            @PathVariable(name = "communityId") Long communityId
+    );
 
     // 커뮤니티 게시글 생성
     @Operation(summary = "게시글 생성", description = "커뮤니티에 게시글을 작성합니다.")

--- a/src/main/java/com/dash/leap/domain/community/dto/response/PostListAllResponse.java
+++ b/src/main/java/com/dash/leap/domain/community/dto/response/PostListAllResponse.java
@@ -1,0 +1,12 @@
+package com.dash.leap.domain.community.dto.response;
+
+import java.time.LocalDate;
+
+public record PostListAllResponse(
+        Long postId,
+        String nickname,
+        LocalDate createdAt,
+        String title,
+        String content,
+        Long commentCount
+) {}

--- a/src/main/java/com/dash/leap/domain/community/repository/CommentRepository.java
+++ b/src/main/java/com/dash/leap/domain/community/repository/CommentRepository.java
@@ -6,4 +6,5 @@ import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+    Long countByPostId(Long postId);
 }

--- a/src/main/java/com/dash/leap/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/dash/leap/domain/community/repository/PostRepository.java
@@ -1,12 +1,12 @@
 package com.dash.leap.domain.community.repository;
 
 import com.dash.leap.domain.community.entity.Post;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
-
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    List<Post> findAllByCommunityId(Long communityId);
+    Page<Post> findAllByCommunityId(Long communityId, Pageable pageable);
 }

--- a/src/main/java/com/dash/leap/domain/community/repository/PostRepository.java
+++ b/src/main/java/com/dash/leap/domain/community/repository/PostRepository.java
@@ -4,7 +4,9 @@ import com.dash.leap.domain.community.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    // 현재는 단순 저장용
+    List<Post> findAllByCommunityId(Long communityId);
 }

--- a/src/main/java/com/dash/leap/domain/community/service/PostService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/PostService.java
@@ -3,9 +3,11 @@ package com.dash.leap.domain.community.service;
 import com.dash.leap.domain.community.dto.request.PostCreateRequest;
 import com.dash.leap.domain.community.dto.response.PostCreateResponse;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
+import com.dash.leap.domain.community.dto.response.PostListAllResponse;
 import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
 import com.dash.leap.domain.community.entity.Community;
 import com.dash.leap.domain.community.entity.Post;
+import com.dash.leap.domain.community.repository.CommentRepository;
 import com.dash.leap.domain.community.repository.CommunityRepository;
 import com.dash.leap.domain.community.repository.PostRepository;
 import com.dash.leap.domain.user.entity.User;
@@ -14,13 +16,34 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class PostService {
 
-    private final PostRepository postRepository;
     private final CommunityRepository communityRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
+
+    // 커뮤니티 게시글 전체 조회
+    @Transactional(readOnly = true)
+    public List<PostListAllResponse> getPostAll(Long communityId) {
+        List<Post> posts = postRepository.findAllByCommunityId(communityId);
+
+        return posts.stream()
+                .map(post -> new PostListAllResponse(
+                        post.getId(),
+                        post.getUser().getNickname(),
+                        post.getCreatedAt().toLocalDate(),
+                        post.getTitle(),
+                        post.getContent(),
+                        commentRepository.countByPostId(post.getId())
+                ))
+                .collect(Collectors.toList());
+    }
 
     // 커뮤니티 게시글 생성
     @Transactional

--- a/src/main/java/com/dash/leap/domain/community/service/PostService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/PostService.java
@@ -13,11 +13,12 @@ import com.dash.leap.domain.community.repository.PostRepository;
 import com.dash.leap.domain.user.entity.User;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -28,21 +29,20 @@ public class PostService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
 
-    // 커뮤니티 게시글 전체 조회
+    // 커뮤니티 게시글 전체 목록 조회
     @Transactional(readOnly = true)
-    public List<PostListAllResponse> getPostAll(Long communityId) {
-        List<Post> posts = postRepository.findAllByCommunityId(communityId);
+    public Page<PostListAllResponse> getPostAll(Long communityId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Post> postPage = postRepository.findAllByCommunityId(communityId, pageable);
 
-        return posts.stream()
-                .map(post -> new PostListAllResponse(
-                        post.getId(),
-                        post.getUser().getNickname(),
-                        post.getCreatedAt().toLocalDate(),
-                        post.getTitle(),
-                        post.getContent(),
-                        commentRepository.countByPostId(post.getId())
-                ))
-                .collect(Collectors.toList());
+        return postPage.map(post -> new PostListAllResponse(
+                post.getId(),
+                post.getUser().getNickname(),
+                post.getCreatedAt().toLocalDate(),
+                post.getTitle(),
+                post.getContent(),
+                commentRepository.countByPostId(post.getId())
+        ));
     }
 
     // 커뮤니티 게시글 생성


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #41

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
커뮤니티별 게시글 전체 목록 조회 기능 구현

+ 리뷰 반영하여 페이징 기능 추가하였습니다.
page, size를 @RequestParam으로 받도록 설정
프론트엔드에서 페이지 번호와 게시글 개수를 기준으로 유연한 페이지네이션 UI를 구성할 수 있도록, 
기존 응답 타입 `List<PostListAllResponse>`를 `Page<PostListAllResponse>`로 변경하였습니다.

## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함