### PR TITLE
Feat #43 커뮤니티 게시글 상세 조회

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/controller/PostController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/PostController.java
@@ -1,6 +1,7 @@
 package com.dash.leap.domain.community.controller;
 
 import com.dash.leap.domain.community.controller.docs.PostControllerDocs;
+import com.dash.leap.domain.community.dto.response.PostDetailResponse;
 import com.dash.leap.domain.community.dto.response.PostListAllResponse;
 import com.dash.leap.domain.community.dto.request.PostCreateRequest;
 import com.dash.leap.domain.community.dto.response.PostCreateResponse;
@@ -28,7 +29,19 @@ public class PostController implements PostControllerDocs {
             @RequestParam(name = "page", defaultValue = "1") int pageNum,
             @RequestParam(name = "size", defaultValue = "10") int pageSize
     ) {
-        return ResponseEntity.ok(postService.getPostAll(communityId, pageNum -1 , pageSize));
+        return ResponseEntity.ok(postService.getPostAll(communityId, pageNum - 1 , pageSize));
+    }
+
+    // 커뮤니티 게시글 상세 조회
+    @GetMapping("/{communityId}/post/{postId}")
+    public ResponseEntity<PostDetailResponse> getPostDetail(
+            @PathVariable Long communityId,
+            @PathVariable Long postId,
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestParam(name = "page", defaultValue = "1") int pageNum,
+            @RequestParam(name = "size", defaultValue = "10") int pageSize
+    ) {
+        return ResponseEntity.ok(postService.getPostDetail(communityId, postId, pageNum - 1, pageSize));
     }
 
     // 커뮤니티 게시글 생성

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
@@ -4,6 +4,7 @@ import com.dash.leap.domain.community.dto.request.PostCreateRequest;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
 import com.dash.leap.domain.community.dto.response.PostCreateResponse;
 import com.dash.leap.domain.community.dto.response.PostListAllResponse;
+import com.dash.leap.domain.community.dto.response.PostDetailResponse;
 import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +24,17 @@ public interface PostControllerDocs {
     @ApiResponse(responseCode = "200", description = "게시글 전체 목록 조회 성공")
     ResponseEntity<Page<PostListAllResponse>> getPostAll(
             @PathVariable(name = "communityId") Long communityId,
+            @RequestParam(name = "page", defaultValue = "1") int pageNum,
+            @RequestParam(name = "size", defaultValue = "10") int pageSize
+    );
+
+    // 커뮤니티 게시글 상세 조회
+    @Operation(summary = "게시글 상세 조회", description = "특정 게시글의 상세 정보와 댓글 목록(페이징)을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "게시글 상세 조회 성공")
+    ResponseEntity<PostDetailResponse> getPostDetail(
+            @PathVariable(name = "communityId") Long communityId,
+            @PathVariable(name = "postId") Long postId,
+            CustomUserDetails userDetails,
             @RequestParam(name = "page", defaultValue = "1") int pageNum,
             @RequestParam(name = "size", defaultValue = "10") int pageSize
     );

--- a/src/main/java/com/dash/leap/domain/community/dto/response/PostDetailResponse.java
+++ b/src/main/java/com/dash/leap/domain/community/dto/response/PostDetailResponse.java
@@ -1,0 +1,24 @@
+package com.dash.leap.domain.community.dto.response;
+
+import org.springframework.data.domain.Page;
+
+import java.time.LocalDate;
+
+public record PostDetailResponse(
+        Long postId,
+        Long userId,
+        String nickname,
+        LocalDate createdAt,
+        String title,
+        String content,
+        Long commentCount,
+        Page<CommentList> comments
+) {
+    public record CommentList(
+            Long commentId,
+            Long userId,
+            String nickname,
+            LocalDate createdAt,
+            String content
+    ) {}
+}

--- a/src/main/java/com/dash/leap/domain/community/repository/CommentRepository.java
+++ b/src/main/java/com/dash/leap/domain/community/repository/CommentRepository.java
@@ -1,10 +1,13 @@
 package com.dash.leap.domain.community.repository;
 
 import com.dash.leap.domain.community.entity.Comment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     Long countByPostId(Long postId);
+    Page<Comment> findByPostId(Long postId, Pageable pageable);
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #43

## 🚀 작업 내용
커뮤니티 특정 게시글에 대한 상세 정보 조회 기능 구현
해당 게시글의 댓글 목록도 함께 페이징하여 반환
현재 로그인한 사용자 ID, 게시글 작성자 ID, 댓글 작성자 ID 포함 -> 프론트엔드에서 현재 로그인 사용자 ID와 비교해 수정/삭제 버튼 노출 가능

## 💬 공유사항

상세 조회가 아닌 게시글 전체 목록 조회에서는 단순히 목록 조회만 가능하고, 수정/삭제 기능이 필요하지 않기 때문에
#42 PR(#41 Feat)에서는 현재 로그인한 사용자 ID나 게시글 작성자 ID는 반환하지 않았습니다.

## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함