### PR TITLE
Refactor #45 게시글 상세 조회에서 userDetails 파라미터 제거

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/controller/PostController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/PostController.java
@@ -37,7 +37,6 @@ public class PostController implements PostControllerDocs {
     public ResponseEntity<PostDetailResponse> getPostDetail(
             @PathVariable Long communityId,
             @PathVariable Long postId,
-            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestParam(name = "page", defaultValue = "1") int pageNum,
             @RequestParam(name = "size", defaultValue = "10") int pageSize
     ) {

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
@@ -34,7 +34,6 @@ public interface PostControllerDocs {
     ResponseEntity<PostDetailResponse> getPostDetail(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
-            CustomUserDetails userDetails,
             @RequestParam(name = "page", defaultValue = "1") int pageNum,
             @RequestParam(name = "size", defaultValue = "10") int pageSize
     );


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #45

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
해당 API는 '조회'에만 사용되는 기능으로, 인증된 사용자 정보를 직접 사용할 필요 X
따라서 서버에서 @AuthenticationPrincipal을 통해 userDetails를 주입할 필요가 없어 해당 파라미터를 제거
프론트엔드에서는 로그인 API에서 받은 userId 값을 저장하여 로그인 유저를 식별하므로, 삭제/수정을 위한 조회자-작성자 일치 확인은 프론트에서 처리 가능

## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함