### PR TITLE
Feat #50 감정일기 작성

### DIFF
--- a/src/main/java/com/dash/leap/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/dash/leap/domain/diary/controller/DiaryController.java
@@ -1,0 +1,28 @@
+package com.dash.leap.domain.diary.controller;
+
+import com.dash.leap.domain.diary.controller.docs.DiaryControllerDocs;
+import com.dash.leap.domain.diary.dto.request.DiaryCreateRequest;
+import com.dash.leap.domain.diary.dto.response.DiaryCreateResponse;
+import com.dash.leap.domain.diary.service.DiaryService;
+import com.dash.leap.global.auth.user.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/diary")
+@RequiredArgsConstructor
+public class DiaryController implements DiaryControllerDocs {
+
+    private final DiaryService diaryService;
+
+    // 감정 일기 생성
+    @PostMapping
+    public ResponseEntity<DiaryCreateResponse> createDiary(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @RequestBody DiaryCreateRequest request
+    ) {
+        return ResponseEntity.ok(diaryService.createDiary(userDetails, request));
+    }
+}

--- a/src/main/java/com/dash/leap/domain/diary/controller/docs/DiaryControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/diary/controller/docs/DiaryControllerDocs.java
@@ -1,0 +1,22 @@
+package com.dash.leap.domain.diary.controller.docs;
+
+import com.dash.leap.domain.diary.dto.request.DiaryCreateRequest;
+import com.dash.leap.domain.diary.dto.response.DiaryCreateResponse;
+import com.dash.leap.global.auth.user.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "Diary", description = "Diary API")
+public interface DiaryControllerDocs {
+
+    // 감정 일기 생성
+    @Operation(summary = "감정 일기 작성", description = "사용자가 감정 일기를 작성하여 등록합니다.")
+    @ApiResponse(responseCode = "200", description = "감정 일기 작성 성공")
+    ResponseEntity<DiaryCreateResponse> createDiary(
+            CustomUserDetails userDetails,
+            @RequestBody DiaryCreateRequest request
+    );
+}

--- a/src/main/java/com/dash/leap/domain/diary/dto/request/DiaryCreateRequest.java
+++ b/src/main/java/com/dash/leap/domain/diary/dto/request/DiaryCreateRequest.java
@@ -1,0 +1,13 @@
+package com.dash.leap.domain.diary.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "감정일기 생성 요청입니다.")
+public record DiaryCreateRequest(
+
+        @Schema(description = "오늘은 어떤 하루를 보냈나요?", example = "오늘은 특별한 일정 없이 오롯이 나를 위한 하루를 보냈다. 좋아하는 음악을 들으며 산책하고, 카페에 들러서 느긋하게 커피를 마셨다.")
+        String daily,
+
+        @Schema(description = "기억에 남는 일이 있었나요?", example = "산책 도중 우연히 마주친 강아지가 나를 반겨줬던 따뜻한 순간이 가장 기억에 남는다. 짧았지만 기분이 몹시 좋아졌다.")
+        String memory
+) {}

--- a/src/main/java/com/dash/leap/domain/diary/dto/response/DiaryCreateResponse.java
+++ b/src/main/java/com/dash/leap/domain/diary/dto/response/DiaryCreateResponse.java
@@ -1,0 +1,19 @@
+package com.dash.leap.domain.diary.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "감정일기 생성 응답입니다.")
+public record DiaryCreateResponse(
+
+        @Schema(description = "감정일기 ID", example = "3")
+        Long diaryId,
+
+        @Schema(description = "오늘은 어떤 하루를 보냈나요?", example = "오늘은 특별한 일정 없이 오롯이 나를 위한 하루를 보냈다. 좋아하는 음악을 들으며 산책하고, 카페에 들러서 느긋하게 커피를 마셨다.")
+        String daily,
+
+        @Schema(description = "기억에 남는 일이 있었나요?", example = "산책 도중 우연히 마주친 강아지가 나를 반겨줬던 따뜻한 순간이 가장 기억에 남는다. 짧았지만 기분이 몹시 좋아졌다.")
+        String memory,
+
+        @Schema(description = "메세지", example = "감정일기가 성공적으로 등록되었습니다.")
+        String message
+) {}

--- a/src/main/java/com/dash/leap/domain/diary/entity/Diary.java
+++ b/src/main/java/com/dash/leap/domain/diary/entity/Diary.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.experimental.SuperBuilder;
 
 import javax.validation.constraints.NotNull;
 
@@ -14,6 +15,7 @@ import static jakarta.persistence.FetchType.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SuperBuilder
 public class Diary extends BaseEntity {
 
     @Id
@@ -25,9 +27,10 @@ public class Diary extends BaseEntity {
     private User user;
 
     @NotNull
-    private String title;
+    @Column(columnDefinition = "TEXT")
+    private String daily;
 
     @NotNull
     @Column(columnDefinition = "TEXT")
-    private String content;
+    private String memory;
 }

--- a/src/main/java/com/dash/leap/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/dash/leap/domain/diary/repository/DiaryRepository.java
@@ -1,0 +1,7 @@
+package com.dash.leap.domain.diary.repository;
+
+import com.dash.leap.domain.diary.entity.Diary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DiaryRepository extends JpaRepository<Diary, Long> {
+}

--- a/src/main/java/com/dash/leap/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/dash/leap/domain/diary/service/DiaryService.java
@@ -1,0 +1,39 @@
+package com.dash.leap.domain.diary.service;
+
+import com.dash.leap.domain.diary.dto.request.DiaryCreateRequest;
+import com.dash.leap.domain.diary.dto.response.DiaryCreateResponse;
+import com.dash.leap.domain.diary.entity.Diary;
+import com.dash.leap.domain.diary.repository.DiaryRepository;
+import com.dash.leap.domain.user.entity.User;
+import com.dash.leap.global.auth.user.CustomUserDetails;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class DiaryService {
+
+    private final DiaryRepository diaryRepository;
+
+    // 감정 일기 생성
+    public DiaryCreateResponse createDiary(CustomUserDetails userDetails, DiaryCreateRequest request) {
+        User user = userDetails.user();
+
+        Diary diary = Diary.builder()
+                .user(user)
+                .daily(request.daily())
+                .memory(request.memory())
+                .build();
+
+        Diary savedDiary = diaryRepository.save(diary);
+
+        return new DiaryCreateResponse(
+                savedDiary.getId(),
+                savedDiary.getDaily(),
+                savedDiary.getMemory(),
+                "감정일기가 성공적으로 등록되었습니다."
+        );
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #50

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
감정일기 작성 기능 구현
(단, 아직 AI 감정 분석 모델, AI 텍스트 요약 모델과 연동 X)

## 💬 공유사항
DB에서 Diary 테이블 필드 수정
1. 기존 title 필드 이름 & 자료형 변경 (변경 후: daily)
2. 기존 content 필드 이름 변경 (변경 후: memory)
<img width="819" alt="스크린샷 2025-04-28 오후 4 29 03" src="https://github.com/user-attachments/assets/5783521e-c394-49e1-ad9f-800511880f22" />



## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함