### PR TITLE
Feat #54 감정일기 월별 캘린더 조회

### DIFF
--- a/src/main/java/com/dash/leap/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/dash/leap/domain/diary/controller/DiaryController.java
@@ -2,6 +2,7 @@ package com.dash.leap.domain.diary.controller;
 
 import com.dash.leap.domain.diary.controller.docs.DiaryControllerDocs;
 import com.dash.leap.domain.diary.dto.request.DiaryCreateRequest;
+import com.dash.leap.domain.diary.dto.response.DiaryCalendarResponse;
 import com.dash.leap.domain.diary.dto.response.DiaryCreateResponse;
 import com.dash.leap.domain.diary.dto.response.DiaryDetailResponse;
 import com.dash.leap.domain.diary.service.DiaryService;
@@ -11,12 +12,23 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/diary")
 @RequiredArgsConstructor
 public class DiaryController implements DiaryControllerDocs {
 
     private final DiaryService diaryService;
+
+    // 감정일기 월별 캘린더 조회
+    @GetMapping
+    public ResponseEntity<List<DiaryCalendarResponse>> getMonthlyCalendar(
+            @RequestParam int year,
+            @RequestParam int month
+    ) {
+        return ResponseEntity.ok(diaryService.getMonthlyCalendar(year, month));
+    }
 
     // 감정일기 상세 조회
     @GetMapping("/{diaryId}")

--- a/src/main/java/com/dash/leap/domain/diary/controller/docs/DiaryControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/diary/controller/docs/DiaryControllerDocs.java
@@ -1,6 +1,7 @@
 package com.dash.leap.domain.diary.controller.docs;
 
 import com.dash.leap.domain.diary.dto.request.DiaryCreateRequest;
+import com.dash.leap.domain.diary.dto.response.DiaryCalendarResponse;
 import com.dash.leap.domain.diary.dto.response.DiaryCreateResponse;
 import com.dash.leap.domain.diary.dto.response.DiaryDetailResponse;
 import com.dash.leap.global.auth.user.CustomUserDetails;
@@ -10,9 +11,20 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
 
 @Tag(name = "Diary", description = "Diary API")
 public interface DiaryControllerDocs {
+
+    // 감정일기 월별 캘린더 조회
+    @Operation(summary = "감정일기 월별 캘린더 조회", description = "해당 연도와 월에 작성된 감정일기 목록과 각 날짜별 감정을 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "감정일기 월별 목록 조회 성공")
+    ResponseEntity<List<DiaryCalendarResponse>> getMonthlyCalendar(
+            @RequestParam(name = "year") int year,
+            @RequestParam(name = "month") int month
+    );
 
     // 감정일기 상세 조회
     @Operation(summary = "감정 일기 상세 조회", description = "diaryId를 기반으로 감정 일기 상세 정보를 조회합니다.")

--- a/src/main/java/com/dash/leap/domain/diary/dto/response/DiaryCalendarResponse.java
+++ b/src/main/java/com/dash/leap/domain/diary/dto/response/DiaryCalendarResponse.java
@@ -1,0 +1,19 @@
+package com.dash.leap.domain.diary.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.LocalDate;
+
+public record DiaryCalendarResponse(
+        @Schema(description = "감정일기 ID", example = "3")
+        Long diaryId,
+
+        @Schema(description = "작성일자", example = "2025-04-12")
+        LocalDate date,
+
+        @Schema(description = "감정 이모지 ID", example = "5")
+        Long emotionId,
+
+        @Schema(description = "감정 이모지", example = "/static/emojis/joy.png")
+        String emoji
+) {}

--- a/src/main/java/com/dash/leap/domain/diary/entity/Diary.java
+++ b/src/main/java/com/dash/leap/domain/diary/entity/Diary.java
@@ -33,4 +33,7 @@ public class Diary extends BaseEntity {
     @NotNull
     @Column(columnDefinition = "TEXT")
     private String memory;
+
+    @OneToOne(mappedBy = "diary", fetch = LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private DiaryAnalysis diaryAnalysis;
 }

--- a/src/main/java/com/dash/leap/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/dash/leap/domain/diary/repository/DiaryRepository.java
@@ -2,8 +2,14 @@ package com.dash.leap.domain.diary.repository;
 
 import com.dash.leap.domain.diary.entity.Diary;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+    @Query("SELECT d FROM Diary d WHERE YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month")
+    List<Diary> findByYearAndMonth(@Param("year") int year, @Param("month") int month);
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #54

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
사용자가 작성한 감정일기의 감정 분석 이모지를 월별 캘린더에서 조회할 수 있도록 구현


## 💬 공유사항
감정일기는 당일에만 작성 가능하다는 전제 하에, created_at 값을 기준으로 해당 날짜를 추출해 월별 데이터를 조회

## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함