### PR TITLE
Refactor #56 diary monthly calendar

### DIFF
--- a/src/main/java/com/dash/leap/domain/diary/dto/response/DiaryDetailResponse.java
+++ b/src/main/java/com/dash/leap/domain/diary/dto/response/DiaryDetailResponse.java
@@ -16,6 +16,9 @@ public record DiaryDetailResponse(
         @Schema(description = "일기 요약 결과", example = "오늘은 즐거운 하루였다.")
         String summary,
 
+        @Schema(description = "감정 이모지 ID", example = "5")
+        Long emotionId,
+
         @Schema(description = "감정 분석 결과", example = "기쁨")
         String category,
 

--- a/src/main/java/com/dash/leap/domain/diary/entity/DiaryAnalysis.java
+++ b/src/main/java/com/dash/leap/domain/diary/entity/DiaryAnalysis.java
@@ -26,7 +26,7 @@ public class DiaryAnalysis {
     @JoinColumn(name = "diary_id", nullable = false)
     private Diary diary;
 
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "emotion_id", nullable = false)
     private Emotion emotion;
 

--- a/src/main/java/com/dash/leap/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/dash/leap/domain/diary/repository/DiaryRepository.java
@@ -1,15 +1,19 @@
 package com.dash.leap.domain.diary.repository;
 
 import com.dash.leap.domain.diary.entity.Diary;
+import com.dash.leap.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
     @Query("SELECT d FROM Diary d WHERE YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month")
     List<Diary> findByYearAndMonth(@Param("year") int year, @Param("month") int month);
+
+    boolean existsByUserAndCreatedAtBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }

--- a/src/main/java/com/dash/leap/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/dash/leap/domain/diary/service/DiaryService.java
@@ -16,6 +16,9 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -73,6 +76,15 @@ public class DiaryService {
     // 감정일기 생성
     public DiaryCreateResponse createDiary(CustomUserDetails userDetails, DiaryCreateRequest request) {
         User user = userDetails.user();
+
+        LocalDateTime startOfToday = LocalDate.now().atStartOfDay();
+        LocalDateTime endOfToday = LocalDate.now().atTime(LocalTime.MAX);
+
+        boolean exists = diaryRepository.existsByUserAndCreatedAtBetween(user, startOfToday, endOfToday);
+
+        if (exists) {
+            throw new IllegalStateException("오늘은 이미 감정일기를 작성하셨습니다.");
+        }
 
         Diary diary = Diary.builder()
                 .user(user)

--- a/src/main/java/com/dash/leap/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/dash/leap/domain/diary/service/DiaryService.java
@@ -64,6 +64,7 @@ public class DiaryService {
                 diary.getDaily(),
                 diary.getMemory(),
                 diaryAnalysis.getSummary(),
+                emotion.getId(),
                 emotion.getCategory(),
                 emotion.getEmoji()
         );


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #56

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
1. 감정일기 이모지 응답 개선
- 감정일기 상세 조회 시 응답에 emotion_id를 추가로 포함 (기존엔 emotion의 카테고리와 이모지만 넘겨줬음)
- 프론트 처리 유연

2. 감정일기 중복 작성 방지
- 동일한 날짜에 이미 감정일기를 작성한 경우, 중복 작성을 방지하도록 백엔드에서 검사 로직을 추가

3. DiaryAnalysis 엔티티의 감정 매핑 수정 및 제약 해제
- @OneToOne 관계였던 emotion 필드를 @ManyToOne으로 변경하여, 하나의 감정이 여러 감정분석에 참조될 수 있도록 수정
- 이에 따라 DB에 설정되어 있던 emotion_id 컬럼의 UNIQUE 제약 조건도 제거

## 💬 공유사항
DiaryAnalysis 엔티티의 emotion 필드를 @ManyToOne으로 수정하였으나, 해당 변경 사항이 DB에 자동 반영되지 않아 로컬 DB에서 직접 수정하여 테스트를 진행하였습니다.
아래는 DB 수정 내역입니다.

1. 왜래키 제거
ALTER TABLE diary_analysis
DROP FOREIGN KEY FKgt98lthmb5gr6du682mie8uw8;

2. UNIQUE 제약 제거
ALTER TABLE diary_analysis
DROP INDEX UKfmcfvgjfcylwrt80san1s3mk2;

3. 외래키 다시 추가
ALTER TABLE diary_analysis
ADD CONSTRAINT FK_diary_analysis_emotion
FOREIGN KEY (emotion_id)
REFERENCES emotion(id)

## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함