### PR TITLE
Fix #57 assign missions

### DIFF
--- a/src/main/java/com/dash/leap/domain/mission/controller/MissionController.java
+++ b/src/main/java/com/dash/leap/domain/mission/controller/MissionController.java
@@ -7,6 +7,8 @@ import com.dash.leap.domain.mission.dto.response.MissionRecordResponse;
 import com.dash.leap.domain.mission.dto.response.UserMissionListResponse;
 import com.dash.leap.domain.mission.entity.enums.MissionStatus;
 import com.dash.leap.domain.mission.service.MissionService;
+import com.dash.leap.domain.mission.dto.request.MissionAreaSettingRequest;
+import com.dash.leap.domain.mission.dto.response.MissionAreaSettingResponse;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,15 @@ import org.springframework.web.bind.annotation.*;
 public class MissionController implements MissionControllerDocs {
 
     private final MissionService missionService;
+
+    @PatchMapping("/area")
+    public ResponseEntity<MissionAreaSettingResponse> missionAreaSetting(
+            @Valid @RequestBody MissionAreaSettingRequest request,
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        MissionAreaSettingResponse settingResponse = missionService.chooseMissionArea(userDetails.user(), request);
+        return ResponseEntity.ok(settingResponse);
+    }
 
     @GetMapping("/goal")
     public ResponseEntity<MissionAreaResponse> readMissionArea(@AuthenticationPrincipal CustomUserDetails userDetails) {

--- a/src/main/java/com/dash/leap/domain/mission/controller/docs/MissionControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/mission/controller/docs/MissionControllerDocs.java
@@ -5,6 +5,8 @@ import com.dash.leap.domain.mission.dto.response.MissionAreaResponse;
 import com.dash.leap.domain.mission.dto.response.MissionRecordResponse;
 import com.dash.leap.domain.mission.dto.response.UserMissionListResponse;
 import com.dash.leap.domain.mission.entity.enums.MissionStatus;
+import com.dash.leap.domain.mission.dto.request.MissionAreaSettingRequest;
+import com.dash.leap.domain.mission.dto.response.MissionAreaSettingResponse;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,6 +19,13 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "Mission", description = "Mission API")
 public interface MissionControllerDocs {
+
+    @Operation(summary = "자립목표영역 선정", description = "자립목표영역설정을 요청합니다.")
+    @ApiResponse(description = "목표설정 성공", responseCode = "200")
+    ResponseEntity<MissionAreaSettingResponse> missionAreaSetting(
+            @Valid MissionAreaSettingRequest request,
+            CustomUserDetails userDetails
+    );
 
     @Operation(summary = "자립목표영역 조회", description = "선택한 자립목표영역 조회를 요청합니다.")
     @ApiResponse(description = "자립목표영역 조회 성공", responseCode = "200")

--- a/src/main/java/com/dash/leap/domain/mission/dto/request/MissionAreaSettingRequest.java
+++ b/src/main/java/com/dash/leap/domain/mission/dto/request/MissionAreaSettingRequest.java
@@ -1,4 +1,4 @@
-package com.dash.leap.domain.user.dto.request;
+package com.dash.leap.domain.mission.dto.request;
 
 import com.dash.leap.domain.mission.entity.enums.MissionType;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/com/dash/leap/domain/mission/dto/response/MissionAreaSettingResponse.java
+++ b/src/main/java/com/dash/leap/domain/mission/dto/response/MissionAreaSettingResponse.java
@@ -1,4 +1,4 @@
-package com.dash.leap.domain.user.dto.response;
+package com.dash.leap.domain.mission.dto.response;
 
 import com.dash.leap.domain.mission.entity.enums.MissionType;
 import com.dash.leap.domain.user.entity.User;

--- a/src/main/java/com/dash/leap/domain/mission/exception/InvalidMissionAreaChangeException.java
+++ b/src/main/java/com/dash/leap/domain/mission/exception/InvalidMissionAreaChangeException.java
@@ -1,4 +1,4 @@
-package com.dash.leap.domain.user.exception;
+package com.dash.leap.domain.mission.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;

--- a/src/main/java/com/dash/leap/domain/mission/exception/MissionExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/mission/exception/MissionExceptionHandler.java
@@ -1,6 +1,5 @@
 package com.dash.leap.domain.mission.exception;
 
-import com.dash.leap.domain.user.exception.InvalidChatbotTypeException;
 import com.dash.leap.global.exception.ExceptionResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.extern.slf4j.Slf4j;
@@ -13,7 +12,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice(basePackages = "com.dash.leap.domain.mission")
 public class MissionExceptionHandler {
 
-    @ExceptionHandler(InvalidChatbotTypeException.class)
+    @ExceptionHandler(InvalidRecordRequestException.class)
     @ApiResponse(responseCode = "400")
     public ResponseEntity<ExceptionResponse> handleInvalidRecordRequestException(InvalidRecordRequestException e) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage());

--- a/src/main/java/com/dash/leap/domain/mission/exception/MissionExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/mission/exception/MissionExceptionHandler.java
@@ -19,4 +19,12 @@ public class MissionExceptionHandler {
         log.info("InvalidRecordRequestExceptionResponse: {}", exceptionResponse);
         return ResponseEntity.badRequest().body(exceptionResponse);
     }
+
+    @ExceptionHandler(InvalidMissionAreaChangeException.class)
+    @ApiResponse(responseCode = "400")
+    public ResponseEntity<ExceptionResponse> handleInvalidMissionAreaChangeException(InvalidMissionAreaChangeException e) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
+        log.info("InvalidMissionAreaChangeExceptionResponse: {}", exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
+    }
 }

--- a/src/main/java/com/dash/leap/domain/mission/repository/MissionRecordRepository.java
+++ b/src/main/java/com/dash/leap/domain/mission/repository/MissionRecordRepository.java
@@ -34,4 +34,6 @@ public interface MissionRecordRepository extends JpaRepository<MissionRecord, Lo
     List<MissionRecord> findAllByUserAndStatus(User user, MissionStatus missionStatus);
 
     Slice<MissionRecord> findAllByUserAndStatusOrderByCompletedTimeDesc(User user, MissionStatus missionStatus, Pageable pageable);
+
+    long countByUserAndStatus(User user, MissionStatus status);
 }

--- a/src/main/java/com/dash/leap/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/dash/leap/domain/mission/repository/MissionRepository.java
@@ -1,0 +1,14 @@
+package com.dash.leap.domain.mission.repository;
+
+import com.dash.leap.domain.mission.entity.Mission;
+import com.dash.leap.domain.mission.entity.enums.MissionType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+
+    List<Mission> findByMissionType(MissionType missionType);
+}

--- a/src/main/java/com/dash/leap/domain/user/controller/UserController.java
+++ b/src/main/java/com/dash/leap/domain/user/controller/UserController.java
@@ -3,11 +3,9 @@ package com.dash.leap.domain.user.controller;
 import com.dash.leap.domain.user.controller.docs.UserControllerDocs;
 import com.dash.leap.domain.user.dto.request.ChatbotSettingRequest;
 import com.dash.leap.domain.user.dto.request.LoginRequest;
-import com.dash.leap.domain.user.dto.request.MissionAreaSettingRequest;
 import com.dash.leap.domain.user.dto.request.UserRegisterRequest;
 import com.dash.leap.domain.user.dto.response.ChatbotSettingResponse;
 import com.dash.leap.domain.user.dto.response.LoginResponse;
-import com.dash.leap.domain.user.dto.response.MissionAreaSettingResponse;
 import com.dash.leap.domain.user.dto.response.UserRegisterResponse;
 import com.dash.leap.domain.user.service.UserService;
 import com.dash.leap.global.auth.user.CustomUserDetails;
@@ -51,15 +49,6 @@ public class UserController implements UserControllerDocs {
     ) {
         ChatbotSettingResponse chatbotSettingResponse = userService.leapySetting(userDetails.user(), request);
         return ResponseEntity.ok(chatbotSettingResponse);
-    }
-
-    @PatchMapping("/mission-area")
-    public ResponseEntity<MissionAreaSettingResponse> missionAreaSetting(
-            @Valid @RequestBody MissionAreaSettingRequest request,
-            @AuthenticationPrincipal CustomUserDetails userDetails
-    ) {
-        MissionAreaSettingResponse settingResponse = userService.missionSetting(userDetails.user(), request);
-        return ResponseEntity.ok(settingResponse);
     }
 
     @PostMapping("/logout")

--- a/src/main/java/com/dash/leap/domain/user/controller/docs/UserControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/user/controller/docs/UserControllerDocs.java
@@ -2,11 +2,9 @@ package com.dash.leap.domain.user.controller.docs;
 
 import com.dash.leap.domain.user.dto.request.ChatbotSettingRequest;
 import com.dash.leap.domain.user.dto.request.LoginRequest;
-import com.dash.leap.domain.user.dto.request.MissionAreaSettingRequest;
 import com.dash.leap.domain.user.dto.request.UserRegisterRequest;
 import com.dash.leap.domain.user.dto.response.ChatbotSettingResponse;
 import com.dash.leap.domain.user.dto.response.LoginResponse;
-import com.dash.leap.domain.user.dto.response.MissionAreaSettingResponse;
 import com.dash.leap.domain.user.dto.response.UserRegisterResponse;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
@@ -35,13 +33,6 @@ public interface UserControllerDocs {
     @ApiResponse(description = "설정 성공", responseCode = "200")
     ResponseEntity<ChatbotSettingResponse> chatbotSetting(
             @Valid ChatbotSettingRequest request,
-            CustomUserDetails userDetails
-    );
-
-    @Operation(summary = "자립목표영역 선정", description = "자립목표영역설정을 요청합니다.")
-    @ApiResponse(description = "목표설정 성공", responseCode = "200")
-    ResponseEntity<MissionAreaSettingResponse> missionAreaSetting(
-            @Valid MissionAreaSettingRequest request,
             CustomUserDetails userDetails
     );
 

--- a/src/main/java/com/dash/leap/domain/user/exception/InvalidMissionAreaChangeException.java
+++ b/src/main/java/com/dash/leap/domain/user/exception/InvalidMissionAreaChangeException.java
@@ -1,0 +1,11 @@
+package com.dash.leap.domain.user.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.BAD_REQUEST)
+public class InvalidMissionAreaChangeException extends RuntimeException {
+    public InvalidMissionAreaChangeException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dash/leap/domain/user/exception/UserExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/user/exception/UserExceptionHandler.java
@@ -14,10 +14,17 @@ public class UserExceptionHandler {
 
     @ExceptionHandler(InvalidChatbotTypeException.class)
     @ApiResponse(responseCode = "400")
-
     public ResponseEntity<ExceptionResponse> handleInvalidChatbotTypeException(InvalidChatbotTypeException e) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
         log.info("InvalidChatbotTypeExceptionResponse: {}", exceptionResponse);
+        return ResponseEntity.badRequest().body(exceptionResponse);
+    }
+
+    @ExceptionHandler(InvalidMissionAreaChangeException.class)
+    @ApiResponse(responseCode = "400")
+    public ResponseEntity<ExceptionResponse> handleInvalidMissionAreaChangeException(InvalidMissionAreaChangeException e) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
+        log.info("InvalidMissionAreaChangeExceptionResponse: {}", exceptionResponse);
         return ResponseEntity.badRequest().body(exceptionResponse);
     }
 }

--- a/src/main/java/com/dash/leap/domain/user/exception/UserExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/user/exception/UserExceptionHandler.java
@@ -19,12 +19,4 @@ public class UserExceptionHandler {
         log.info("InvalidChatbotTypeExceptionResponse: {}", exceptionResponse);
         return ResponseEntity.badRequest().body(exceptionResponse);
     }
-
-    @ExceptionHandler(InvalidMissionAreaChangeException.class)
-    @ApiResponse(responseCode = "400")
-    public ResponseEntity<ExceptionResponse> handleInvalidMissionAreaChangeException(InvalidMissionAreaChangeException e) {
-        ExceptionResponse exceptionResponse = new ExceptionResponse(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
-        log.info("InvalidMissionAreaChangeExceptionResponse: {}", exceptionResponse);
-        return ResponseEntity.badRequest().body(exceptionResponse);
-    }
 }

--- a/src/main/java/com/dash/leap/domain/user/service/UserService.java
+++ b/src/main/java/com/dash/leap/domain/user/service/UserService.java
@@ -2,24 +2,15 @@ package com.dash.leap.domain.user.service;
 
 import com.dash.leap.domain.chat.entity.Chat;
 import com.dash.leap.domain.chat.repository.ChatRepository;
-import com.dash.leap.domain.mission.entity.Mission;
-import com.dash.leap.domain.mission.entity.MissionRecord;
-import com.dash.leap.domain.mission.entity.enums.MissionStatus;
-import com.dash.leap.domain.mission.entity.enums.MissionType;
-import com.dash.leap.domain.mission.repository.MissionRecordRepository;
-import com.dash.leap.domain.mission.repository.MissionRepository;
 import com.dash.leap.domain.user.dto.request.ChatbotSettingRequest;
 import com.dash.leap.domain.user.dto.request.LoginRequest;
-import com.dash.leap.domain.user.dto.request.MissionAreaSettingRequest;
 import com.dash.leap.domain.user.dto.request.UserRegisterRequest;
 import com.dash.leap.domain.user.dto.response.ChatbotSettingResponse;
 import com.dash.leap.domain.user.dto.response.LoginResponse;
-import com.dash.leap.domain.user.dto.response.MissionAreaSettingResponse;
 import com.dash.leap.domain.user.dto.response.UserRegisterResponse;
 import com.dash.leap.domain.user.entity.User;
 import com.dash.leap.domain.user.entity.enums.ChatbotType;
 import com.dash.leap.domain.user.entity.enums.UserType;
-import com.dash.leap.domain.user.exception.InvalidMissionAreaChangeException;
 import com.dash.leap.domain.user.repository.UserRepository;
 import com.dash.leap.global.auth.jwt.exception.DuplicateLoginIdException;
 import com.dash.leap.global.auth.jwt.exception.PasswordMismatchException;
@@ -32,11 +23,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -47,8 +33,6 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final ChatRepository chatRepository;
-    private final MissionRepository missionRepository;
-    private final MissionRecordRepository missionRecordRepository;
 
     @Transactional
     public UserRegisterResponse register(UserRegisterRequest request) {
@@ -105,53 +89,6 @@ public class UserService {
     }
 
     @Transactional
-    public MissionAreaSettingResponse missionSetting(User user, MissionAreaSettingRequest request) {
-
-        User findUser = findUserByIdInUserRepository(user);
-        log.info("[UserService] 자립영역 설정 시작: 사용자 ID = {}", findUser.getId());
-
-        if (findUser.getMissionType() == null) {
-            log.info("[UserService] 온보딩 진행: 초기 자립영역을 설정합니다.");
-            findUser.setMissionType(request.missionType());
-        } else {
-            log.info("[UserService] 새로운 자립영역을 설정합니다.");
-
-            if (missionRecordRepository.countByUserAndStatus(findUser, MissionStatus.ONGOING) != 0) {
-                throw new InvalidMissionAreaChangeException("현재 선택한 영역의 미션을 모두 완료해야 다른 영역을 선택할 수 있습니다.");
-            }
-
-            log.info("[UserService] 완료했던 영역을 확인합니다.");
-            List<MissionRecord> completedMissions = missionRecordRepository.findAllByUserAndStatus(findUser, MissionStatus.COMPLETED);
-            Set<MissionType> completedAreas = completedMissions.stream()
-                    .map(m -> m.getMission().getMissionType())
-                    .collect(Collectors.toSet());
-
-            if (completedAreas.contains(request.missionType())) {
-                throw new InvalidMissionAreaChangeException("이미 완료한 영역은 다시 선택할 수 없습니다.");
-            }
-
-            log.info("[UserService] 자립영역을 변경을 승인합니다: before = {}", findUser.getMissionType());
-            findUser.setMissionType(request.missionType());
-            log.info("[UserService] 자립영역 변경에 성공했습니다: after = {}", findUser.getMissionType());
-
-        }
-
-        List<Mission> missions = missionRepository.findByMissionType(request.missionType());
-
-        for (Mission mission : missions) {
-            MissionRecord userMission = MissionRecord.builder()
-                    .user(findUser)
-                    .mission(mission)
-                    .assignedTime(LocalDateTime.now())
-                    .status(MissionStatus.ONGOING)
-                    .build();
-            missionRecordRepository.save(userMission);
-        }
-
-        return MissionAreaSettingResponse.from(findUser);
-    }
-
-    @Transactional
     public void logout(User user) {
         log.info("로그아웃 요청: userId = {}", user.getId());
         // Redis 이용 시 Blacklist 추가하는 방향으로 수정
@@ -165,10 +102,5 @@ public class UserService {
 
     public boolean checkLoginIdDuplicate(String loginId) {
         return userRepository.existsByLoginId(loginId);
-    }
-
-    private User findUserByIdInUserRepository(User user) {
-        return userRepository.findById(user.getId())
-                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다: 사용자 ID = " + user.getId()));
     }
 }

--- a/src/main/java/com/dash/leap/domain/user/service/UserService.java
+++ b/src/main/java/com/dash/leap/domain/user/service/UserService.java
@@ -2,6 +2,12 @@ package com.dash.leap.domain.user.service;
 
 import com.dash.leap.domain.chat.entity.Chat;
 import com.dash.leap.domain.chat.repository.ChatRepository;
+import com.dash.leap.domain.mission.entity.Mission;
+import com.dash.leap.domain.mission.entity.MissionRecord;
+import com.dash.leap.domain.mission.entity.enums.MissionStatus;
+import com.dash.leap.domain.mission.entity.enums.MissionType;
+import com.dash.leap.domain.mission.repository.MissionRecordRepository;
+import com.dash.leap.domain.mission.repository.MissionRepository;
 import com.dash.leap.domain.user.dto.request.ChatbotSettingRequest;
 import com.dash.leap.domain.user.dto.request.LoginRequest;
 import com.dash.leap.domain.user.dto.request.MissionAreaSettingRequest;
@@ -13,6 +19,7 @@ import com.dash.leap.domain.user.dto.response.UserRegisterResponse;
 import com.dash.leap.domain.user.entity.User;
 import com.dash.leap.domain.user.entity.enums.ChatbotType;
 import com.dash.leap.domain.user.entity.enums.UserType;
+import com.dash.leap.domain.user.exception.InvalidMissionAreaChangeException;
 import com.dash.leap.domain.user.repository.UserRepository;
 import com.dash.leap.global.auth.jwt.exception.DuplicateLoginIdException;
 import com.dash.leap.global.auth.jwt.exception.PasswordMismatchException;
@@ -25,6 +32,11 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -35,6 +47,8 @@ public class UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
     private final ChatRepository chatRepository;
+    private final MissionRepository missionRepository;
+    private final MissionRecordRepository missionRecordRepository;
 
     @Transactional
     public UserRegisterResponse register(UserRegisterRequest request) {
@@ -92,8 +106,49 @@ public class UserService {
 
     @Transactional
     public MissionAreaSettingResponse missionSetting(User user, MissionAreaSettingRequest request) {
-        user.setMissionType(request.missionType());
-        return MissionAreaSettingResponse.from(user);
+
+        User findUser = findUserByIdInUserRepository(user);
+        log.info("[UserService] 자립영역 설정 시작: 사용자 ID = {}", findUser.getId());
+
+        if (findUser.getMissionType() == null) {
+            log.info("[UserService] 온보딩 진행: 초기 자립영역을 설정합니다.");
+            findUser.setMissionType(request.missionType());
+        } else {
+            log.info("[UserService] 새로운 자립영역을 설정합니다.");
+
+            if (missionRecordRepository.countByUserAndStatus(findUser, MissionStatus.ONGOING) != 0) {
+                throw new InvalidMissionAreaChangeException("현재 선택한 영역의 미션을 모두 완료해야 다른 영역을 선택할 수 있습니다.");
+            }
+
+            log.info("[UserService] 완료했던 영역을 확인합니다.");
+            List<MissionRecord> completedMissions = missionRecordRepository.findAllByUserAndStatus(findUser, MissionStatus.COMPLETED);
+            Set<MissionType> completedAreas = completedMissions.stream()
+                    .map(m -> m.getMission().getMissionType())
+                    .collect(Collectors.toSet());
+
+            if (completedAreas.contains(request.missionType())) {
+                throw new InvalidMissionAreaChangeException("이미 완료한 영역은 다시 선택할 수 없습니다.");
+            }
+
+            log.info("[UserService] 자립영역을 변경을 승인합니다: before = {}", findUser.getMissionType());
+            findUser.setMissionType(request.missionType());
+            log.info("[UserService] 자립영역 변경에 성공했습니다: after = {}", findUser.getMissionType());
+
+        }
+
+        List<Mission> missions = missionRepository.findByMissionType(request.missionType());
+
+        for (Mission mission : missions) {
+            MissionRecord userMission = MissionRecord.builder()
+                    .user(findUser)
+                    .mission(mission)
+                    .assignedTime(LocalDateTime.now())
+                    .status(MissionStatus.ONGOING)
+                    .build();
+            missionRecordRepository.save(userMission);
+        }
+
+        return MissionAreaSettingResponse.from(findUser);
     }
 
     @Transactional
@@ -110,5 +165,10 @@ public class UserService {
 
     public boolean checkLoginIdDuplicate(String loginId) {
         return userRepository.existsByLoginId(loginId);
+    }
+
+    private User findUserByIdInUserRepository(User user) {
+        return userRepository.findById(user.getId())
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다: 사용자 ID = " + user.getId()));
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #57 

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
자립영역 선택 시 사용자에게 해당 영역의 미션 5개를 부여하는 로직을 구현했습니다.
상황은 아래의 2가지로 나뉩니다.

1. 온보딩 시
`mission_area` 필드가 `null`일 경우 온보딩으로 간주하고 설정을 진행합니다.

2. 한 영역을 끝내고 다시 영역을 설정할 시
`mission_area` 필드가 `null`이 아닐 경우 설정을 진행합니다.
이전에 진행했던 영역은 다시 진행할 수 없습니다.

또한 DB에 변경 내용이 반영이 되지 않은 오류가 발생했었습니다. 
이는 `userDetails.user()`로 받은 객체는 영속 상태가 아니기 때문에 JPA에서 관리하지 못해서 발생하게 된 오류였습니다. 따라서 `userRepository`에서 `findById()`를 통해 영속된 엔티티를 꺼내오고 이 `user`를 사용하는 방식으로 변경함으로써 오류를 수정했습니다.

## 💬 공유사항
온보딩뿐만 아니라 한 영역을 끝내고 다른 자립영역을 선택할 수 있게 하여 `/user/mission-area` 에서 `/mission/area` 로 URI를 변경했습니다. 이에 따라 `user` 패키지에 있던 자립영역 선택 관련 로직을 `mission` 패키지로 리팩토링하였습니다.

## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함