### PR TITLE
Refactor #69 감정일기 예외 처리 보완

### DIFF
--- a/src/main/java/com/dash/leap/domain/diary/exception/ConflictException.java
+++ b/src/main/java/com/dash/leap/domain/diary/exception/ConflictException.java
@@ -1,0 +1,7 @@
+package com.dash.leap.domain.diary.exception;
+
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dash/leap/domain/diary/exception/DiaryExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/diary/exception/DiaryExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.dash.leap.domain.diary.exception;
+
+import com.dash.leap.global.exception.ExceptionResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class DiaryExceptionHandler {
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ExceptionResponse> handleConflictException(ConflictException e) {
+        ExceptionResponse response = new ExceptionResponse("409", e.getMessage());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
+    }
+}

--- a/src/main/java/com/dash/leap/global/exception/ExceptionResponse.java
+++ b/src/main/java/com/dash/leap/global/exception/ExceptionResponse.java
@@ -2,9 +2,8 @@ package com.dash.leap.global.exception;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "예외에 대한 응답 형식입니다.")
+@Schema(description = "예외 응답")
 public record ExceptionResponse(
-        String status,
-        String message
-) {
-}
+        @Schema(description = "HTTP 상태 코드", example = "상태 코드") String status,
+        @Schema(description = "에러 메시지", example = "에러 메시지") String message
+) {}


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #69

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
1.감정일기 기능 전반에 대한 예외 처리를 보완

NotFoundException 은 전역(Global) 예외로 정의된 클래스를 활용
	•	존재하지 않는 감정일기
	•	감정 분석 결과가 없는 경우
	•	감정 정보가 없는 경우

ConflictException 은 감정일기 도메인 내부에 새롭게 정의
	•	하루에 한 번 이상 감정일기를 작성하려는 경우

2. ExceptionResponse에 example 추가

## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함