### PR TITLE
Refactor #68 커뮤니티 예외 처리 보완

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/exception/BadRequestException.java
+++ b/src/main/java/com/dash/leap/domain/community/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.dash.leap.domain.community.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dash/leap/domain/community/exception/CommunityExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/community/exception/CommunityExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.dash.leap.domain.community.exception;
+
+import com.dash.leap.global.exception.ExceptionResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class CommunityExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> handleBadRequestException(BadRequestException e) {
+        ExceptionResponse response = new ExceptionResponse("400", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ExceptionResponse> handleForbiddenException(ForbiddenException e) {
+        ExceptionResponse response = new ExceptionResponse("403", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
+}
+
+

--- a/src/main/java/com/dash/leap/domain/community/exception/ForbiddenException.java
+++ b/src/main/java/com/dash/leap/domain/community/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.dash.leap.domain.community.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #68

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
커뮤니티 기능 전반에 대한 예외 처리를 보완

NotFoundException 은 전역(Global) 예외로 정의된 클래스를 활용
• 존재하지 않는 커뮤니티
• 존재하지 않는 게시글
• 존재하지 않는 댓글

BadRequestException 은 커뮤니티 도메인 내부에 새롭게 정의
• 해당 커뮤니티에 속한 게시글/댓글이 아닐 경우
• 해당 게시글에 속한 댓글이 아닐 경우

ForbiddenException 은 커뮤니티 도메인 내부에 새롭게 정의
• 사용자가 작성자가 아닌 게시글을 수정/삭제 시도할 경우 
• 사용자가 작성자가 아닌 댓글을 삭제 시도할 경우 


## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함