### PR TITLE
Refactor #72 예외 처리 범위 및 메시지 개선 

### DIFF
--- a/src/main/java/com/dash/leap/domain/community/exception/CommunityExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/community/exception/CommunityExceptionHandler.java
@@ -6,7 +6,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.dash.leap.domain.community")
 public class CommunityExceptionHandler {
 
     @ExceptionHandler(BadRequestException.class)

--- a/src/main/java/com/dash/leap/domain/community/service/CommentService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/CommentService.java
@@ -64,12 +64,13 @@ public class CommentService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
 
         Post post = comment.getPost();
-        if (!post.getId().equals(postId)) {
-            throw new BadRequestException("해당 댓글은 요청한 게시글에 속하지 않습니다.");
-        }
 
         if (!post.getCommunity().getId().equals(communityId)) {
-            throw new BadRequestException("해당 게시글은 요청한 커뮤니티에 속하지 않습니다.");
+            throw new BadRequestException("해당 커뮤니티에 속한 게시글이 아닙니다.");
+        }
+
+        if (!post.getId().equals(postId)) {
+            throw new BadRequestException("해당 게시글에 속한 댓글이 아닙니다.");
         }
 
         if (!comment.getUser().getId().equals(user.getId())) {

--- a/src/main/java/com/dash/leap/domain/community/service/PostService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/PostService.java
@@ -144,7 +144,7 @@ public class PostService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 커뮤니티입니다."));
 
         if (!post.getCommunity().getId().equals(communityId)) {
-            throw new BadRequestException("요청한 커뮤니티에 해당 게시글이 존재하지 않습니다.");
+            throw new BadRequestException("해당 커뮤니티에 속한 게시글이 아닙니다.");
         }
 
         if (!post.getUser().getId().equals(user.getId())) {

--- a/src/main/java/com/dash/leap/domain/diary/exception/DiaryExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/diary/exception/DiaryExceptionHandler.java
@@ -6,7 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
-@RestControllerAdvice
+@RestControllerAdvice(basePackages = "com.dash.leap.domain.diary")
 public class DiaryExceptionHandler {
 
     @ExceptionHandler(ConflictException.class)

--- a/src/main/java/com/dash/leap/domain/diary/service/DiaryService.java
+++ b/src/main/java/com/dash/leap/domain/diary/service/DiaryService.java
@@ -59,7 +59,7 @@ public class DiaryService {
                 .orElseThrow(() -> new NotFoundException("존재하지 않는 감정일기입니다."));
 
         DiaryAnalysis diaryAnalysis = diaryAnalysisRepository.findByDiaryId(diaryId)
-                .orElseThrow(() -> new NotFoundException("해당 일기에 대한 분석 결과가 없습니다."));
+                .orElseThrow(() -> new NotFoundException("해당 분석 결과가 없습니다."));
 
         Emotion emotion = emotionRepository.findById(diaryAnalysis.getEmotion().getId())
                 .orElseThrow(() -> new NotFoundException("해당 감정 정보가 없습니다."));


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #72

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
1. CommunityExceptionHandler, DiaryExceptionHandler에 basePackages 옵션 추가
예외 핸들러의 적용 범위를 각 도메인 패키지로 제한

2. 예외 메시지 수정

## 💬 공유사항


## ✅ PR 체크리스트
- [✅] 이슈 번호를 맞게 작성함
- [✅] 로컬에서 정상 작동 확인함
- [✅] 커밋 메시지 컨벤션에 맞게 작성함