### PR TITLE
Fix #74 회원탈퇴 로직 수정

### DIFF
--- a/src/main/java/com/dash/leap/domain/user/entity/User.java
+++ b/src/main/java/com/dash/leap/domain/user/entity/User.java
@@ -62,7 +62,13 @@ public class User {
     @Enumerated(EnumType.STRING)
     private UserType userType = UserType.USER;
 
+    private boolean isDeleted = false;
+
     public void chooseChatbot(ChatbotType chatbotType) {
         this.chatbotType = chatbotType;
+    }
+
+    public void changeUserStatus(boolean isDeleted) {
+        this.isDeleted = isDeleted;
     }
 }

--- a/src/main/java/com/dash/leap/domain/user/service/UserService.java
+++ b/src/main/java/com/dash/leap/domain/user/service/UserService.java
@@ -88,8 +88,7 @@ public class UserService {
 
     @Transactional
     public ChatbotSettingResponse leapySetting(User user, ChatbotSettingRequest request) {
-        User findUser = userRepository.findById(user.getId())
-                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다: 사용자 ID = " + user.getId()));
+        User findUser = findUserByIdOrElseThrow(user);
 
         log.info("[UserService] 온보딩: 챗봇(리피) 설정을 시작합니다.");
         if (findUser.getChatbotType() != null) {
@@ -118,10 +117,16 @@ public class UserService {
     @Transactional
     public void withdraw(User user) {
         log.warn("회원탈퇴 요청: userId = {}", user.getId());
-        userRepository.delete(user);
+        User findUser = findUserByIdOrElseThrow(user);
+        findUser.changeUserStatus(true);
     }
 
     public boolean checkLoginIdDuplicate(String loginId) {
         return userRepository.existsByLoginId(loginId);
+    }
+
+    private User findUserByIdOrElseThrow(User user) {
+        return userRepository.findById(user.getId())
+                .orElseThrow(() -> new NotFoundException("사용자를 찾을 수 없습니다: 사용자 ID = " + user.getId()));
     }
 }

--- a/src/main/java/com/dash/leap/domain/user/service/UserService.java
+++ b/src/main/java/com/dash/leap/domain/user/service/UserService.java
@@ -75,8 +75,13 @@ public class UserService {
 
     @Transactional
     public LoginResponse login(LoginRequest request) {
+
         User user = userRepository.findByLoginId(request.loginId())
                 .orElseThrow(() -> new NotFoundException("존재하지 않은 아이디입니다."));
+
+        if (user.isDeleted()) {
+            throw new UnauthorizedException("탈퇴한 회원은 로그인할 수 없습니다.");
+        }
 
         if (!passwordEncoder.matches(request.password(), user.getPassword())) {
             throw new UnauthorizedException("비밀번호가 일치하지 않습니다.");

--- a/src/main/java/com/dash/leap/global/auth/jwt/service/JwtAuthenticationFilter.java
+++ b/src/main/java/com/dash/leap/global/auth/jwt/service/JwtAuthenticationFilter.java
@@ -1,13 +1,17 @@
 package com.dash.leap.global.auth.jwt.service;
 
+import com.dash.leap.global.auth.jwt.exception.UnauthorizedException;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import com.dash.leap.global.auth.user.CustomUserService;
+import com.dash.leap.global.exception.ExceptionResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.jsonwebtoken.Claims;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
@@ -21,27 +25,38 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserService customUserService;
+    private final ObjectMapper objectMapper;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
-        String token = extractToken(request);
+        try {
+            String token = extractToken(request);
 
-        if (token != null) {
-            jwtTokenProvider.validateToken(token);
-            Claims claims = jwtTokenProvider.getPayload(token);
+            if (token != null) {
+                jwtTokenProvider.validateToken(token);
+                Claims claims = jwtTokenProvider.getPayload(token);
 
-            Long userId = claims.get("id", Long.class);
+                Long userId = claims.get("id", Long.class);
 
-            CustomUserDetails userDetails = customUserService.loadUserById(userId);
+                CustomUserDetails userDetails = customUserService.loadUserById(userId);
 
-            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
-            authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
 
-            SecurityContextHolder.getContext().setAuthentication(authentication);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+
+            filterChain.doFilter(request, response);
+        } catch (UnauthorizedException e) {
+
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setContentType("application/json;charset=UTF-8");
+
+            ExceptionResponse body = new ExceptionResponse(HttpStatus.UNAUTHORIZED.toString(), e.getMessage());
+
+            response.getWriter().write(objectMapper.writeValueAsString(body));
         }
-
-        filterChain.doFilter(request, response);
     }
 
     private String extractToken(HttpServletRequest request) {

--- a/src/main/java/com/dash/leap/global/auth/user/CustomUserService.java
+++ b/src/main/java/com/dash/leap/global/auth/user/CustomUserService.java
@@ -15,6 +15,11 @@ public class CustomUserService {
     public CustomUserDetails loadUserById(Long userId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UnauthorizedException("유효하지 않은 사용자입니다."));
+
+        if (user.isDeleted()) {
+            throw new UnauthorizedException("탈퇴한 회원입니다.");
+        }
+
         return new CustomUserDetails(user);
     }
 

--- a/src/main/java/com/dash/leap/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/dash/leap/global/config/security/SecurityConfig.java
@@ -41,7 +41,7 @@ public class SecurityConfig {
                         )
                         .permitAll()
                         .anyRequest().authenticated())
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserService), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider, customUserService, objectMapper), UsernamePasswordAuthenticationFilter.class)
                 .formLogin(AbstractAuthenticationFilterConfigurer::disable)
                 .exceptionHandling(e -> e
                         .authenticationEntryPoint(getAuthenticationEntryPoint()))


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #74

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
회원 탈퇴 관련해서 연관관계로 인해 탈퇴가 안 되는 오류 수정했습니다.

## 💬 공유사항
기존: DB에서 바로 삭제
변경: Soft delete 반영
`User` 엔티티에 `isDeleted` 라는 필드 추가하고, 해당 필드가 `true`가 되었을 경우 회원 탈퇴로 간주하는 로직으로 변경했습니다.
또한, 탈퇴한 회원인지 확인하기 위해 `CustomUserService`에 탈퇴한 회원인지를 확인하는 로직 추가했습니다.

## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함