### PR TITLE
Refactor #89 커뮤니티 게시글 및 댓글 삭제 응답 메시지 추가

### DIFF
--- a/src/main/java/com/dash/leap/admin/community/controller/AdminCommunityController.java
+++ b/src/main/java/com/dash/leap/admin/community/controller/AdminCommunityController.java
@@ -1,9 +1,7 @@
 package com.dash.leap.admin.community.controller;
 
 import com.dash.leap.admin.community.controller.docs.AdminCommunityControllerDocs;
-import com.dash.leap.admin.community.dto.response.CategoryListResponse;
-import com.dash.leap.admin.community.dto.response.PostDetailResponse;
-import com.dash.leap.admin.community.dto.response.PostListAllResponse;
+import com.dash.leap.admin.community.dto.response.*;
 import com.dash.leap.admin.community.service.AdminCommunityService;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -50,7 +48,7 @@ public class AdminCommunityController implements AdminCommunityControllerDocs {
 
     // [관리자] 커뮤니티 게시글 삭제
     @DeleteMapping("/{communityId}/{postId}")
-    public ResponseEntity<Void> deletePost(
+    public ResponseEntity<PostDeleteResponse> deletePost(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             @AuthenticationPrincipal CustomUserDetails userDetails
@@ -61,7 +59,7 @@ public class AdminCommunityController implements AdminCommunityControllerDocs {
 
     // [관리자] 커뮤니티 댓글 삭제
     @DeleteMapping("/{communityId}/{postId}/{commentId}")
-    public ResponseEntity<Void> deleteComment(
+    public ResponseEntity<CommentDeleteResponse> deleteComment(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             @PathVariable(name = "commentId") Long commentId,

--- a/src/main/java/com/dash/leap/admin/community/controller/docs/AdminCommunityControllerDocs.java
+++ b/src/main/java/com/dash/leap/admin/community/controller/docs/AdminCommunityControllerDocs.java
@@ -1,8 +1,6 @@
 package com.dash.leap.admin.community.controller.docs;
 
-import com.dash.leap.admin.community.dto.response.CategoryListResponse;
-import com.dash.leap.admin.community.dto.response.PostDetailResponse;
-import com.dash.leap.admin.community.dto.response.PostListAllResponse;
+import com.dash.leap.admin.community.dto.response.*;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,7 +12,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
-@Tag(name = "[Admin] community", description = "Admin Community API")
+@Tag(name = "[Admin] Community", description = "Admin Community API")
 public interface AdminCommunityControllerDocs {
 
     // [관리자] 커뮤니티 카테고리 목록 조회
@@ -44,7 +42,7 @@ public interface AdminCommunityControllerDocs {
     // [관리자] 커뮤니티 게시글 삭제
     @Operation(summary = "게시글 삭제", description = "커뮤니티의 특정 게시글을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "게시글 삭제 성공")
-    ResponseEntity<Void> deletePost(
+    ResponseEntity<PostDeleteResponse> deletePost(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             CustomUserDetails userDetails
@@ -53,7 +51,7 @@ public interface AdminCommunityControllerDocs {
     // [관리자] 커뮤니티 댓글 삭제
     @Operation(summary = "댓글 삭제", description = "커뮤니티 게시글의 댓글을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "댓글 삭제 성공")
-    ResponseEntity<Void> deleteComment(
+    ResponseEntity<CommentDeleteResponse> deleteComment(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             @PathVariable(name = "commentId") Long commentId,

--- a/src/main/java/com/dash/leap/admin/community/dto/response/CommentDeleteResponse.java
+++ b/src/main/java/com/dash/leap/admin/community/dto/response/CommentDeleteResponse.java
@@ -1,0 +1,11 @@
+package com.dash.leap.admin.community.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CommentDeleteResponse(
+        @Schema(description = "댓글 ID", example = "5")
+        Long commentId,
+
+        @Schema(description = "메시지", example = "댓글이 성공적으로 삭제되었습니다.")
+        String message
+) {}

--- a/src/main/java/com/dash/leap/admin/community/dto/response/PostDeleteResponse.java
+++ b/src/main/java/com/dash/leap/admin/community/dto/response/PostDeleteResponse.java
@@ -1,0 +1,11 @@
+package com.dash.leap.admin.community.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PostDeleteResponse(
+        @Schema(description = "게시글 ID", example = "5")
+        Long postId,
+
+        @Schema(description = "메시지", example = "게시글이 성공적으로 삭제되었습니다.")
+        String message
+) {}

--- a/src/main/java/com/dash/leap/admin/community/service/AdminCommunityService.java
+++ b/src/main/java/com/dash/leap/admin/community/service/AdminCommunityService.java
@@ -1,8 +1,6 @@
 package com.dash.leap.admin.community.service;
 
-import com.dash.leap.admin.community.dto.response.CategoryListResponse;
-import com.dash.leap.admin.community.dto.response.PostDetailResponse;
-import com.dash.leap.admin.community.dto.response.PostListAllResponse;
+import com.dash.leap.admin.community.dto.response.*;
 import com.dash.leap.domain.community.entity.Comment;
 import com.dash.leap.domain.community.entity.Post;
 import com.dash.leap.admin.community.exception.ForbiddenException;
@@ -98,7 +96,7 @@ public class AdminCommunityService {
 
     // [관리자] 커뮤니티 게시글 삭제
     @Transactional
-    public void delete(Long communityId, Long postId, CustomUserDetails userDetails) {
+    public PostDeleteResponse delete(Long communityId, Long postId, CustomUserDetails userDetails) {
         User user = userDetails.user();
 
         Post post = postRepository.findById(postId)
@@ -113,11 +111,13 @@ public class AdminCommunityService {
         }
 
         postRepository.delete(post);
+
+        return new PostDeleteResponse(postId, "게시글이 성공적으로 삭제되었습니다.");
     }
 
     // [관리자] 커뮤니티 댓글 삭제
     @Transactional
-    public void delete(Long communityId, Long postId, Long commentId, CustomUserDetails userDetails) {
+    public CommentDeleteResponse delete(Long communityId, Long postId, Long commentId, CustomUserDetails userDetails) {
         User user = userDetails.user();
 
         Comment comment = commentRepository.findById(commentId)
@@ -138,5 +138,7 @@ public class AdminCommunityService {
         }
 
         commentRepository.delete(comment);
+
+        return new CommentDeleteResponse(commentId, "댓글이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/CommentController.java
@@ -3,6 +3,7 @@ package com.dash.leap.domain.community.controller;
 import com.dash.leap.domain.community.controller.docs.CommentControllerDocs;
 import com.dash.leap.domain.community.dto.request.CommentCreateRequest;
 import com.dash.leap.domain.community.dto.response.CommentCreateResponse;
+import com.dash.leap.domain.community.dto.response.CommentDeleteResponse;
 import com.dash.leap.domain.community.service.CommentService;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class CommentController implements CommentControllerDocs {
 
     // 커뮤니티 댓글 삭제
     @DeleteMapping("/{communityId}/{postId}/{commentId}")
-    public ResponseEntity<Void> deleteComment(
+    public ResponseEntity<CommentDeleteResponse> deleteComment(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             @PathVariable(name = "commentId") Long commentId,

--- a/src/main/java/com/dash/leap/domain/community/controller/PostController.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/PostController.java
@@ -1,12 +1,9 @@
 package com.dash.leap.domain.community.controller;
 
 import com.dash.leap.domain.community.controller.docs.PostControllerDocs;
-import com.dash.leap.domain.community.dto.response.PostDetailResponse;
-import com.dash.leap.domain.community.dto.response.PostListAllResponse;
+import com.dash.leap.domain.community.dto.response.*;
 import com.dash.leap.domain.community.dto.request.PostCreateRequest;
-import com.dash.leap.domain.community.dto.response.PostCreateResponse;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
-import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
 import com.dash.leap.domain.community.service.PostService;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
@@ -81,7 +78,7 @@ public class PostController implements PostControllerDocs {
 
     // 커뮤니티 게시글 삭제
     @DeleteMapping("/{communityId}/{postId}")
-    public ResponseEntity<Void> deletePost(
+    public ResponseEntity<PostDeleteResponse> deletePost(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             @AuthenticationPrincipal CustomUserDetails userDetails

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/CommentControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/CommentControllerDocs.java
@@ -2,6 +2,7 @@ package com.dash.leap.domain.community.controller.docs;
 
 import com.dash.leap.domain.community.dto.request.CommentCreateRequest;
 import com.dash.leap.domain.community.dto.response.CommentCreateResponse;
+import com.dash.leap.domain.community.dto.response.CommentDeleteResponse;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -26,7 +27,7 @@ public interface CommentControllerDocs {
     // 커뮤니티 댓글 삭제
     @Operation(summary = "댓글 삭제", description = "커뮤니티 게시글의 댓글을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "댓글 삭제 성공")
-    ResponseEntity<Void> deleteComment(
+    ResponseEntity<CommentDeleteResponse> deleteComment(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             @PathVariable(name = "commentId") Long commentId,

--- a/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/community/controller/docs/PostControllerDocs.java
@@ -2,10 +2,7 @@ package com.dash.leap.domain.community.controller.docs;
 
 import com.dash.leap.domain.community.dto.request.PostCreateRequest;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
-import com.dash.leap.domain.community.dto.response.PostCreateResponse;
-import com.dash.leap.domain.community.dto.response.PostListAllResponse;
-import com.dash.leap.domain.community.dto.response.PostDetailResponse;
-import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
+import com.dash.leap.domain.community.dto.response.*;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -74,7 +71,7 @@ public interface PostControllerDocs {
     // 커뮤니티 게시글 삭제
     @Operation(summary = "게시글 삭제", description = "커뮤니티의 특정 게시글을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "게시글 삭제 성공")
-    ResponseEntity<Void> deletePost(
+    ResponseEntity <PostDeleteResponse> deletePost(
             @PathVariable(name = "communityId") Long communityId,
             @PathVariable(name = "postId") Long postId,
             CustomUserDetails userDetails

--- a/src/main/java/com/dash/leap/domain/community/dto/response/CommentDeleteResponse.java
+++ b/src/main/java/com/dash/leap/domain/community/dto/response/CommentDeleteResponse.java
@@ -1,0 +1,11 @@
+package com.dash.leap.domain.community.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record CommentDeleteResponse(
+        @Schema(description = "댓글 ID", example = "3")
+        Long commentId,
+
+        @Schema(description = "메시지", example = "댓글이 성공적으로 삭제되었습니다.")
+        String message
+) {}

--- a/src/main/java/com/dash/leap/domain/community/dto/response/PostDeleteResponse.java
+++ b/src/main/java/com/dash/leap/domain/community/dto/response/PostDeleteResponse.java
@@ -1,0 +1,11 @@
+package com.dash.leap.domain.community.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record PostDeleteResponse(
+        @Schema(description = "게시글 ID", example = "3")
+        Long postId,
+
+        @Schema(description = "메시지", example = "게시글이 성공적으로 삭제되었습니다.")
+        String message
+) {}

--- a/src/main/java/com/dash/leap/domain/community/service/CommentService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/CommentService.java
@@ -2,6 +2,7 @@ package com.dash.leap.domain.community.service;
 
 import com.dash.leap.domain.community.dto.request.CommentCreateRequest;
 import com.dash.leap.domain.community.dto.response.CommentCreateResponse;
+import com.dash.leap.domain.community.dto.response.CommentDeleteResponse;
 import com.dash.leap.domain.community.entity.Post;
 import com.dash.leap.domain.community.entity.Comment;
 import com.dash.leap.domain.community.exception.BadRequestException;
@@ -57,7 +58,7 @@ public class CommentService {
 
     // 커뮤니티 댓글 삭제
     @Transactional
-    public void delete(Long communityId, Long postId, Long commentId, CustomUserDetails userDetails) {
+    public CommentDeleteResponse delete(Long communityId, Long postId, Long commentId, CustomUserDetails userDetails) {
         User user = userDetails.user();
 
         Comment comment = commentRepository.findById(commentId)
@@ -78,5 +79,7 @@ public class CommentService {
         }
 
         commentRepository.delete(comment);
+
+        return new CommentDeleteResponse(comment.getId(), "댓글이 성공적으로 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/dash/leap/domain/community/service/PostService.java
+++ b/src/main/java/com/dash/leap/domain/community/service/PostService.java
@@ -1,11 +1,8 @@
 package com.dash.leap.domain.community.service;
 
 import com.dash.leap.domain.community.dto.request.PostCreateRequest;
-import com.dash.leap.domain.community.dto.response.PostCreateResponse;
+import com.dash.leap.domain.community.dto.response.*;
 import com.dash.leap.domain.community.dto.request.PostUpdateRequest;
-import com.dash.leap.domain.community.dto.response.PostDetailResponse;
-import com.dash.leap.domain.community.dto.response.PostListAllResponse;
-import com.dash.leap.domain.community.dto.response.PostUpdateResponse;
 import com.dash.leap.domain.community.entity.Comment;
 import com.dash.leap.domain.community.entity.Community;
 import com.dash.leap.domain.community.entity.Post;
@@ -163,7 +160,7 @@ public class PostService {
 
     // 커뮤니티 게시글 삭제
     @Transactional
-    public void delete(Long communityId, Long postId, CustomUserDetails userDetails) {
+    public PostDeleteResponse delete(Long communityId, Long postId, CustomUserDetails userDetails) {
         User user = userDetails.user();
 
         Post post = postRepository.findById(postId)
@@ -178,5 +175,7 @@ public class PostService {
         }
 
         postRepository.delete(post);
+
+        return new PostDeleteResponse(post.getId(), "게시글이 성공적으로 삭제되었습니다.");
     }
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #89

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
관리자(Admin) 및 일반 사용자(Domain) 영역 모두에서
게시글/댓글 삭제 시 DeleteResponse DTO를 통해 삭제 성공 메시지 반환

## 💬 공유사항


## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함