### PR TITLE
Feature #87 Admin 대시보드

### DIFF
--- a/src/main/java/com/dash/leap/admin/user/controller/AdminDashboardController.java
+++ b/src/main/java/com/dash/leap/admin/user/controller/AdminDashboardController.java
@@ -1,0 +1,23 @@
+package com.dash.leap.admin.user.controller;
+
+import com.dash.leap.admin.user.dto.response.AdminDashboardResponse;
+import com.dash.leap.admin.user.service.AdminDashboardService;
+import com.dash.leap.admin.user.controller.docs.AdminDashboardControllerDocs;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/dashboard")
+public class AdminDashboardController implements AdminDashboardControllerDocs {
+
+    private final AdminDashboardService adminDashboardService;
+
+    @GetMapping
+    public ResponseEntity<AdminDashboardResponse> getDashboard() {
+        return ResponseEntity.ok(adminDashboardService.getDashboardData());
+    }
+}

--- a/src/main/java/com/dash/leap/admin/user/controller/docs/AdminDashboardControllerDocs.java
+++ b/src/main/java/com/dash/leap/admin/user/controller/docs/AdminDashboardControllerDocs.java
@@ -1,0 +1,17 @@
+package com.dash.leap.admin.user.controller.docs;
+
+import com.dash.leap.admin.user.dto.response.AdminDashboardResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "[Admin] Dashboard", description = "Admin Dashboard API")
+public interface AdminDashboardControllerDocs {
+
+    @Operation(summary = "관리자 대시보드", description = "총 이용자 수, 미션 수, 자립지원정보 수, 게시글 수를 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "대시보드 통계 조회 성공")
+    @GetMapping
+    ResponseEntity<AdminDashboardResponse> getDashboard();
+}

--- a/src/main/java/com/dash/leap/admin/user/dto/response/AdminDashboardResponse.java
+++ b/src/main/java/com/dash/leap/admin/user/dto/response/AdminDashboardResponse.java
@@ -1,0 +1,17 @@
+package com.dash.leap.admin.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record AdminDashboardResponse(
+        @Schema(description = "총 이용자 수", example = "102")
+        long userCount,
+
+        @Schema(description = "총 미션 수", example = "30")
+        long missionCount,
+
+        @Schema(description = "총 자립지원정보 수", example = "42")
+        long informationCount,
+
+        @Schema(description = "총 게시글 수", example = "158")
+        long postCount
+) {}

--- a/src/main/java/com/dash/leap/admin/user/service/AdminDashboardService.java
+++ b/src/main/java/com/dash/leap/admin/user/service/AdminDashboardService.java
@@ -1,0 +1,34 @@
+package com.dash.leap.admin.user.service;
+
+
+import com.dash.leap.admin.user.dto.response.AdminDashboardResponse;
+import com.dash.leap.domain.community.repository.PostRepository;
+import com.dash.leap.domain.information.repository.InformationRepository;
+import com.dash.leap.domain.mission.repository.MissionRepository;
+import com.dash.leap.domain.user.repository.UserRepository;
+import com.dash.leap.domain.user.entity.enums.UserType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminDashboardService {
+
+    private final UserRepository userRepository;
+    private final MissionRepository missionRepository;
+    private final InformationRepository informationRepository;
+    private final PostRepository postRepository;
+
+    public AdminDashboardResponse getDashboardData() {
+        long userCount = userRepository.countByUserType(UserType.USER);
+
+        return new AdminDashboardResponse(
+                userCount,
+                missionRepository.count(),
+                informationRepository.count(),
+                postRepository.count()
+        );
+    }
+}

--- a/src/main/java/com/dash/leap/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/dash/leap/domain/user/repository/UserRepository.java
@@ -1,6 +1,7 @@
 package com.dash.leap.domain.user.repository;
 
 import com.dash.leap.domain.user.entity.User;
+import com.dash.leap.domain.user.entity.enums.UserType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -12,4 +13,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByLoginId(String loginId);
 
     Optional<User> findByLoginId(String loginId);
+
+    long countByUserType(UserType userType);
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #87

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
• 관리자 대시보드 API /admin/dashboard 구현
• 총 이용자 수 / 미션 수 / 자립지원정보 수 / 게시글 수 통계를 반환
• UserType이 USER인 일반 사용자만 집계 대상으로 포함

## 💬 공유사항


## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함