### PR TITLE
Fix #97 감정일기 조회

### DIFF
--- a/src/main/java/com/dash/leap/domain/diary/controller/DiaryController.java
+++ b/src/main/java/com/dash/leap/domain/diary/controller/DiaryController.java
@@ -8,7 +8,6 @@ import com.dash.leap.domain.diary.dto.response.DiaryDetailResponse;
 import com.dash.leap.domain.diary.service.DiaryService;
 import com.dash.leap.global.auth.user.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -28,17 +27,19 @@ public class DiaryController implements DiaryControllerDocs {
     @GetMapping
     public ResponseEntity<List<DiaryCalendarResponse>> getMonthlyCalendar(
             @RequestParam int year,
-            @RequestParam int month
+            @RequestParam int month,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return ResponseEntity.ok(diaryService.getMonthlyCalendar(year, month));
+        return ResponseEntity.ok(diaryService.getMonthlyCalendar(year, month, userDetails));
     }
 
     // 감정일기 상세 조회
     @GetMapping("/{diaryId}")
     public ResponseEntity<DiaryDetailResponse> getDiaryDetail(
-            @PathVariable(name = "diaryId") Long diaryId
+            @PathVariable(name = "diaryId") Long diaryId,
+            @AuthenticationPrincipal CustomUserDetails userDetails
     ) {
-        return ResponseEntity.ok(diaryService.getDiaryDetail(diaryId));
+        return ResponseEntity.ok(diaryService.getDiaryDetail(diaryId, userDetails));
     }
 
     // 감정일기 생성

--- a/src/main/java/com/dash/leap/domain/diary/controller/docs/DiaryControllerDocs.java
+++ b/src/main/java/com/dash/leap/domain/diary/controller/docs/DiaryControllerDocs.java
@@ -23,14 +23,16 @@ public interface DiaryControllerDocs {
     @ApiResponse(responseCode = "200", description = "감정일기 월별 목록 조회 성공")
     ResponseEntity<List<DiaryCalendarResponse>> getMonthlyCalendar(
             @RequestParam(name = "year") int year,
-            @RequestParam(name = "month") int month
+            @RequestParam(name = "month") int month,
+            CustomUserDetails userDetails
     );
 
     // 감정일기 상세 조회
     @Operation(summary = "감정 일기 상세 조회", description = "diaryId를 기반으로 감정 일기 상세 정보를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "감정일기 상세 조회 성공")
     ResponseEntity<DiaryDetailResponse> getDiaryDetail(
-            @PathVariable(name = "diaryId") Long diaryId
+            @PathVariable(name = "diaryId") Long diaryId,
+            CustomUserDetails userDetails
     );
 
     // 감정일기 생성

--- a/src/main/java/com/dash/leap/domain/diary/exception/DiaryExceptionHandler.java
+++ b/src/main/java/com/dash/leap/domain/diary/exception/DiaryExceptionHandler.java
@@ -14,4 +14,10 @@ public class DiaryExceptionHandler {
         ExceptionResponse response = new ExceptionResponse("409", e.getMessage());
         return ResponseEntity.status(HttpStatus.CONFLICT).body(response);
     }
+
+    @ExceptionHandler(ForbiddenException.class)
+    public ResponseEntity<ExceptionResponse> handleForbiddenException(ForbiddenException e) {
+        ExceptionResponse response = new ExceptionResponse("403", e.getMessage());
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(response);
+    }
 }

--- a/src/main/java/com/dash/leap/domain/diary/exception/ForbiddenException.java
+++ b/src/main/java/com/dash/leap/domain/diary/exception/ForbiddenException.java
@@ -1,0 +1,7 @@
+package com.dash.leap.domain.diary.exception;
+
+public class ForbiddenException extends RuntimeException {
+    public ForbiddenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/dash/leap/domain/diary/repository/DiaryRepository.java
+++ b/src/main/java/com/dash/leap/domain/diary/repository/DiaryRepository.java
@@ -12,8 +12,8 @@ import java.util.List;
 
 @Repository
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
-    @Query("SELECT d FROM Diary d WHERE YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month")
-    List<Diary> findByYearAndMonth(@Param("year") int year, @Param("month") int month);
+    @Query("SELECT d FROM Diary d WHERE YEAR(d.createdAt) = :year AND MONTH(d.createdAt) = :month AND d.user.id = :userId")
+    List<Diary> findByYearAndMonthAndUserId(@Param("year") int year, @Param("month") int month, @Param("userId") Long userId);
 
     boolean existsByUserAndCreatedAtBetween(User user, LocalDateTime startOfDay, LocalDateTime endOfDay);
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #97

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
월별 캘린더 조회 시 & 감정일기 상세 조회 시,
로그인한 사용자가 작성한 일기만 조회되도록 수정

## 💬 공유사항


## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함