### PR TITLE
Feature #100 챗봇에게 분석된 감정 및 요약된 일기 시스템 프롬프트로 넘겨주는 로직 구현

### DIFF
--- a/src/main/java/com/dash/leap/domain/chat/service/prompt/SystemPromptFactory.java
+++ b/src/main/java/com/dash/leap/domain/chat/service/prompt/SystemPromptFactory.java
@@ -1,40 +1,74 @@
 package com.dash.leap.domain.chat.service.prompt;
 
+import com.dash.leap.domain.diary.entity.DiaryAnalysis;
 import com.dash.leap.domain.user.entity.enums.ChatbotType;
+
+import java.util.List;
+import java.util.Map;
 
 public class SystemPromptFactory {
 
-    public static String getSystemPrompt(ChatbotType type) {
+    public static String getSystemPrompt(ChatbotType type, List<DiaryAnalysis> recentDiaryAnal) {
 
-        String prompt = """
-                너의 이름은 '리피'야.
-                이 앱의 사용자는 '자립준비청년이야'.
-                너는 자립준비청년을 위한 챗봇이야.
-                """;
+        // 공통 프롬프트
+        StringBuilder prompt = new StringBuilder("""
+            너의 이름은 '리피'야.
+            이 앱의 사용자는 '자립준비청년'이야.
+            너는 자립준비청년을 위한 챗봇이야.
+            아래는 사용자의 최근 감정일기 분석 내용이야.
+            이 정보를 바탕으로 사용자의 감정을 공감하고, 성격에 맞게 대화를 이끌어줘.
+            너무 무겁지 않게, 친구처럼 다정하게 말해줘.
+            \n
+        """);
 
-        switch (type) {
-            case FF -> prompt += """
-                        넌 여자이고, 따뜻한 조언자 같은 친구야.
-                        너는 다정하고, 공감 능력이 뛰어나.
-                        사용자가 힘든 상황에서도 따뜻한 말과 격려를 건네며, 현식적인 조언도 함께 제공해줘야 해.
-                        """;
-            case FT -> prompt += """
-                        넌 여자이고, 현실적인 멘토 같은 친구야.
-                        너는 논리적이고, 현식적인 조언을 해줘.
-                        감성적인 위로도 해줘야 하지만, 그보다도 실질적인 해결책을 제시하면서 목표 설정을 도와줘야 해.
-                        """;
-            case MF -> prompt += """
-                        넌 남자이고, 긍정 에너자이저로 가득한 친구야.
-                        너는 활발하고, 긍정적인 응원을 보내주는 친구야.
-                        사용자의 고민을 너무 무겁게 다루기 보다는 가볍게 대화하면서 사용자의 기분을 전환해줘야 해.
-                        """;
-            case MT -> prompt += """
-                        넌 남자이고, 쿨하고 믿음직한 형 또는 오빠 같은 친구야.
-                        너는 감정에 크게 휘둘리지 않으면서도, 조용히 옆에서 힘이 되어주는 든든한 친구야.
-                        사용자에게 부담스럽지 않은 조언을 해주면서, 필요할 땐 확실하게 방향을 잡아줘야 해.
-                        """;
+        // 요약 문장 추가
+        if (!recentDiaryAnal.isEmpty()) {
+            prompt.append("[감정일기 요약]\n");
+            for (DiaryAnalysis analysis : recentDiaryAnal) {
+                prompt.append("- ").append(analysis.getSummary()).append("\n");
+            }
+
+            prompt.append("\n[최근 감정 점수 분석]\n");
+
+            // 최신 감정 점수 기준 (ex. 오늘 or 어제 중 마지막 분석)
+            Map<String, Double> scores = recentDiaryAnal.get(recentDiaryAnal.size() - 1).getEmotionScore();
+
+            scores.entrySet().stream()
+                    .sorted((a, b) -> Double.compare(b.getValue(), a.getValue()))
+                    .forEach(e -> {
+                        String emotionName = e.getKey();
+                        double score = Math.round(e.getValue() * 10.0) / 10.0; // 소수점 한 자리 반올림
+                        prompt.append("- ").append(emotionName).append(": ").append(score).append("\n");
+                    });
+        } else {
+            prompt.append("사용자의 최근 감정일기 분석 정보가 없어.\n");
         }
 
-        return prompt;
+        // 성격별 추가 프롬프트
+        prompt.append("\n[리피의 성격 정보]\n");
+        prompt.append(switch (type) {
+            case FF -> """
+                너는 여자이고, 따뜻한 조언자 같은 친구야.
+                공감 능력이 뛰어나고, 다정한 말투를 사용해.
+                상대가 지친 날엔 위로를, 평범한 날엔 격려를 해줘.
+            """;
+            case FT -> """
+                너는 여자이고, 현실적인 멘토 같은 친구야.
+                감정은 존중하되, 해결책 중심으로 이야기해줘.
+                실질적인 조언을 제공하면서 동기를 부여해줘.
+            """;
+            case MF -> """
+                너는 남자이고, 긍정 에너자이저 같은 친구야.
+                분위기를 유쾌하게 전환시켜주는 밝은 성격이야.
+                너무 무겁지 않게 말하면서도, 상대의 감정을 배려해줘.
+            """;
+            case MT -> """
+                너는 남자이고, 믿음직한 형 또는 오빠 같은 친구야.
+                조용하지만 단단한 말투로 상대를 안심시켜줘.
+                차분하게 조언하면서 안정감을 줘야 해.
+            """;
+        });
+
+        return prompt.toString();
     }
 }

--- a/src/main/java/com/dash/leap/domain/diary/repository/DiaryAnalysisRepository.java
+++ b/src/main/java/com/dash/leap/domain/diary/repository/DiaryAnalysisRepository.java
@@ -1,12 +1,17 @@
 package com.dash.leap.domain.diary.repository;
 
 import com.dash.leap.domain.diary.entity.DiaryAnalysis;
+import com.dash.leap.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface DiaryAnalysisRepository extends JpaRepository<DiaryAnalysis, Long> {
     Optional<DiaryAnalysis> findByDiaryId(Long diaryId);
+
+    List<DiaryAnalysis> findByDiary_UserAndAnalysisTimeBetween(User user, LocalDateTime start, LocalDateTime end);
 }


### PR DESCRIPTION
## 📌 이슈 번호
<!-- 이슈 번호 작성 ex: #1 -->
closed #100

## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
챗봇 시스템 프롬프트에 사용자의 가장 최근(어제 또는 오늘 중)에 작성된 감정일기를 기반으로 분석된 감정 및 요약된 일기를 시스템 프롬프트에 넘겨주는 로직 구현했습니다.
챗봇은 이를 바탕으로 사용자와 맞춤형 대화를 하게 됩니다.
만약 어제 또는 오늘 중으로 작성된 일기가 없을 경우 '분석된 내용이 없음' 으로 들어가게 됩니다.

## 💬 공유사항


## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함