### PR TITLE
Fix: 삭제된 미션도 들어가게 되는 버그 수정

### DIFF
--- a/src/main/java/com/dash/leap/domain/mission/repository/MissionRepository.java
+++ b/src/main/java/com/dash/leap/domain/mission/repository/MissionRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface MissionRepository extends JpaRepository<Mission, Long> {
 
     List<Mission> findByMissionType(MissionType missionType);
+
+    List<Mission> findByMissionTypeAndIsDeletedFalse(MissionType missionType);
 }

--- a/src/main/java/com/dash/leap/domain/mission/service/MissionService.java
+++ b/src/main/java/com/dash/leap/domain/mission/service/MissionService.java
@@ -75,7 +75,7 @@ public class MissionService {
 
         }
 
-        List<Mission> missions = missionRepository.findByMissionType(request.missionType());
+        List<Mission> missions = missionRepository.findByMissionTypeAndIsDeletedFalse(request.missionType());
 
         for (Mission mission : missions) {
             MissionRecord userMission = MissionRecord.builder()


### PR DESCRIPTION
## 🚀 작업 내용
<!-- 어떤 기능을 구현했는지 간단히 작성 -->
회원가입 시 삭제된 미션도 들어가게 되는 버그 수정했습니다.


## ✅ PR 체크리스트
- [x] 이슈 번호를 맞게 작성함
- [x] 로컬에서 정상 작동 확인함
- [x] 커밋 메시지 컨벤션에 맞게 작성함